### PR TITLE
Allow various calculations to be disabled

### DIFF
--- a/src/lupy/meter.py
+++ b/src/lupy/meter.py
@@ -36,11 +36,12 @@ class Meter(Generic[NumChannelsT]):
 
     .. important::
 
-        If *short_term_enabled* is ``False``, *lra_enabled* must also be ``False``
-        or a :class:`ValueError` will be raised.
-
+        If *short_term_enabled* is ``False``, *lra_enabled* must also be ``False``.
         This is because :term:`Loudness Range` calculation depends on
         :term:`Short-Term Loudness` values.
+
+    Raises:
+        ValueError: If *short_term_enabled* is ``False`` and *lra_enabled* is ``True``
 
     """
 

--- a/src/lupy/meter.py
+++ b/src/lupy/meter.py
@@ -261,10 +261,17 @@ class Meter(Generic[NumChannelsT]):
 
     @property
     def true_peak_max(self) -> Floating:
-        """Maximum :term:`True Peak` value detected"""
+        """Maximum :term:`True Peak` value detected
+
+        If :attr:`true_peak_enabled` is ``False``, this will always return ``-inf``.
+        """
         return self.true_peak_processor.max_peak
 
     @property
     def true_peak_current(self) -> np.ndarray[tuple[NumChannelsT], np.dtype[np.float64]]:
-        """:term:`True Peak` values per channel from the last processing period"""
+        """:term:`True Peak` values per channel from the last processing period
+
+        If :attr:`true_peak_enabled` is ``False``, this will always return
+        an array of ``-inf`` values.
+        """
         return self.true_peak_processor.current_peaks

--- a/tests/test_meter_options.py
+++ b/tests/test_meter_options.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+from typing import Iterable
+
+import pytest
+import numpy as np
+
+from lupy import Meter
+from lupy.types import Float2dArray, NumChannels
+
+from conftest import gen_1k_sine
+
+
+
+def build_samples(
+    num_samples: int,
+    sample_rate: int,
+    num_channels: NumChannels = 2,
+    sine_channels: Iterable[int]|None = (0, 1),
+    sine_amp: float = 10 ** (-18/20),
+) -> Float2dArray:
+    samples = np.zeros((num_channels, num_samples), dtype=np.float64)
+    if sine_channels is not None:
+        sig = gen_1k_sine(num_samples, sample_rate, sine_amp)
+        samples[np.array(sine_channels),...] = sig
+    return samples
+
+
+
+def test_momentary_disabled():
+    sample_rate = 48000
+    block_size = 128
+    num_channels = 2
+    meter = Meter(
+        block_size=block_size,
+        num_channels=num_channels,
+        sample_rate=sample_rate,
+        momentary_enabled=False,
+    )
+    assert not meter.momentary_enabled
+    assert meter.short_term_enabled
+    assert meter.lra_enabled
+
+    N = meter.sampler.total_samples
+    src_data = build_samples(N, sample_rate, num_channels)
+    meter.write_all(src_data)
+
+    assert round(meter.integrated_lkfs, 2) == -18
+    assert np.array_equal(meter.momentary_lkfs, np.zeros_like(meter.momentary_lkfs))
+    assert not np.array_equal(meter.short_term_lkfs, np.zeros_like(meter.short_term_lkfs))
+    assert meter.lra != 0.0
+    assert meter.true_peak_max != -np.inf
+    tp_array = meter.true_peak_array['tp']
+    assert not np.array_equal(tp_array, np.full_like(tp_array, -np.inf))
+
+
+def test_short_term_disabled_and_lra_enabled_raises():
+    sample_rate = 48000
+    block_size = 128
+    num_channels = 2
+
+    # LRA requires short-term to be enabled which raises an error.
+    with pytest.raises(ValueError) as excinfo:
+        meter = Meter(
+            block_size=block_size,
+            num_channels=num_channels,
+            sample_rate=sample_rate,
+            short_term_enabled=False,
+            lra_enabled=True,
+        )
+    assert 'lra' in str(excinfo.value).lower() and 'short-term' in str(excinfo.value).lower()
+
+
+def test_short_term_disabled():
+    sample_rate = 48000
+    block_size = 128
+    num_channels = 2
+
+    meter = Meter(
+        block_size=block_size,
+        num_channels=num_channels,
+        sample_rate=sample_rate,
+        short_term_enabled=False,
+        lra_enabled=False,
+    )
+    assert not meter.short_term_enabled
+    assert not meter.lra_enabled
+    assert meter.momentary_enabled
+
+    N = meter.sampler.total_samples
+    src_data = build_samples(N, sample_rate, num_channels)
+    meter.write_all(src_data)
+
+    assert round(meter.integrated_lkfs, 2) == -18
+    assert not np.array_equal(meter.momentary_lkfs, np.zeros_like(meter.momentary_lkfs))
+    assert np.array_equal(meter.short_term_lkfs, np.zeros_like(meter.short_term_lkfs))
+    assert meter.lra == 0.0
+    assert meter.true_peak_max != -np.inf
+    tp_array = meter.true_peak_array['tp']
+    assert not np.array_equal(tp_array, np.full_like(tp_array, -np.inf))
+
+
+def test_lra_disabled():
+    sample_rate = 48000
+    block_size = 128
+    num_channels = 2
+    meter = Meter(
+        block_size=block_size,
+        num_channels=num_channels,
+        sample_rate=sample_rate,
+        lra_enabled=False,
+    )
+    assert not meter.lra_enabled
+    assert meter.momentary_enabled
+    assert meter.short_term_enabled
+
+    N = meter.sampler.total_samples
+    src_data = build_samples(N, sample_rate, num_channels)
+    meter.write_all(src_data)
+
+    assert round(meter.integrated_lkfs, 2) == -18
+    assert not np.array_equal(meter.momentary_lkfs, np.zeros_like(meter.momentary_lkfs))
+    assert not np.array_equal(meter.short_term_lkfs, np.zeros_like(meter.short_term_lkfs))
+    assert meter.lra == 0.0
+    assert meter.true_peak_max != -np.inf
+    tp_array = meter.true_peak_array['tp']
+    assert not np.array_equal(tp_array, np.full_like(tp_array, -np.inf))
+
+
+def test_true_peak_disabled():
+    sample_rate = 48000
+    block_size = 128
+    num_channels = 2
+    meter = Meter(
+        block_size=block_size,
+        num_channels=num_channels,
+        sample_rate=sample_rate,
+        true_peak_enabled=False,
+    )
+    assert not meter.true_peak_enabled
+
+    N = meter.sampler.total_samples
+    src_data = build_samples(N, sample_rate, num_channels)
+    meter.write_all(src_data)
+
+    assert round(meter.integrated_lkfs, 2) == -18
+    assert not np.array_equal(meter.momentary_lkfs, np.zeros_like(meter.momentary_lkfs))
+    assert not np.array_equal(meter.short_term_lkfs, np.zeros_like(meter.short_term_lkfs))
+    assert meter.lra != 0.0
+    assert meter.true_peak_max == -np.inf
+    tp_array = meter.true_peak_array['tp']
+    assert np.array_equal(tp_array, np.full_like(tp_array, -np.inf))

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -33,7 +33,15 @@ def build_samples(
 
 def test_integrated_lkfs(sample_rate, block_size, all_channels, is_silent):
     num_channels, sine_channel = all_channels
-    meter = Meter(block_size=block_size, num_channels=num_channels, sample_rate=sample_rate)
+    meter = Meter(
+        block_size=block_size,
+        num_channels=num_channels,
+        sample_rate=sample_rate,
+        true_peak_enabled=False,
+        momentary_enabled=False,
+        short_term_enabled=False,
+        lra_enabled=False,
+    )
 
     N, Fs = meter.sampler.total_samples, int(meter.sample_rate)
     num_blocks, gate_size = meter.sampler.num_blocks, meter.sampler.gate_size
@@ -65,7 +73,15 @@ def test_integrated_lkfs(sample_rate, block_size, all_channels, is_silent):
 # Stereo 1k (997 Hz) sine at -18 dBFS should read -18 LUFS
 def test_integrated_lkfs_neg18(sample_rate, block_size):
     num_channels = 2
-    meter = Meter(block_size=block_size, num_channels=num_channels, sample_rate=sample_rate)
+    meter = Meter(
+        block_size=block_size,
+        num_channels=num_channels,
+        sample_rate=sample_rate,
+        true_peak_enabled=False,
+        momentary_enabled=False,
+        short_term_enabled=False,
+        lra_enabled=False,
+    )
 
     N, Fs = meter.sampler.total_samples, int(meter.sample_rate)
     num_blocks, gate_size = meter.sampler.num_blocks, meter.sampler.gate_size
@@ -139,7 +155,15 @@ def test_bs2217_compliance_cases(bs_2217_compliance_case):
     sample_rate = 48000
     block_size = 128
     num_channels = bs_2217_compliance_case.num_channels
-    meter = Meter(block_size=block_size, num_channels=num_channels, sample_rate=sample_rate)
+    meter = Meter(
+        block_size=block_size,
+        num_channels=num_channels,
+        sample_rate=sample_rate,
+        true_peak_enabled=False,
+        momentary_enabled=False,
+        short_term_enabled=False,
+        lra_enabled=False,
+    )
 
     print('generating samples...')
     src_data = bs_2217_compliance_case.generate_samples(
@@ -180,6 +204,10 @@ def test_true_peak_gate_blocks(
         num_channels=num_channels,
         sample_rate=sample_rate,
         true_peak_gate_duration=true_peak_gate_duration,
+        true_peak_enabled=True,
+        momentary_enabled=False,
+        short_term_enabled=False,
+        lra_enabled=False,
     )
 
     print('generating samples...')


### PR DESCRIPTION
# Add options to enable/disable specific loudness measurements

### TL;DR

Added configuration options to selectively enable or disable specific loudness measurements (True Peak, Momentary, Short-Term, and Loudness Range) in the Meter class.

### What changed?

- Added boolean parameters to `Meter.__init__()` to control which measurements are enabled:
  - `true_peak_enabled` (default: True)
  - `momentary_enabled` (default: True)
  - `short_term_enabled` (default: True)
  - `lra_enabled` (default: True)
- Added read-only properties to check which measurements are enabled
- Modified processing logic to skip disabled measurements
- Added validation to ensure LRA is disabled when Short-Term is disabled (since LRA depends on Short-Term)
- Updated return values for disabled measurements:
  - Disabled momentary/short-term measurements return arrays of zeros
  - Disabled LRA returns 0.0
  - Disabled True Peak returns -infinity
- Added comprehensive tests for all combinations of disabled measurements

### How to test?

Run the new test file `tests/test_meter_options.py` which verifies:
- Disabling momentary loudness works correctly
- Disabling short-term loudness works correctly
- Disabling LRA works correctly
- Disabling true peak works correctly
- Attempting to enable LRA while disabling short-term raises an appropriate error

### Why make this change?

This change allows users to optimize performance by disabling measurements they don't need. For applications that only require specific loudness metrics, this reduces unnecessary processing and improves efficiency.