### PR TITLE
Combine K-weighting filters into a single filter

### DIFF
--- a/src/lupy/filters.py
+++ b/src/lupy/filters.py
@@ -17,7 +17,7 @@ from .types import *
 from .signalutils.sosfilt import sosfilt, validate_sos
 from .signalutils.resample import ResamplePoly, calc_tp_fir_win
 from .typeutils import (
-    ensure_1d_array, ensure_2d_array, is_3d_array,
+    ensure_1d_array, ensure_2d_array, is_3d_array, is_1d_array, is_float64_array,
 )
 
 T = TypeVar('T')
@@ -31,6 +31,19 @@ class Coeff:
     a: Float1dArray             #: Denominator of the filter
     sample_rate: int = 48000    #: Sample rate of the filter
     _sos: SosCoeff|None = None
+
+    @classmethod
+    def from_sos(cls, sos: SosCoeff, sample_rate: int = 48000) -> Self:
+        """Create a :class:`Coeff` instance from second-order sections
+
+        This is the inverse of :attr:`sos` property.
+        """
+        b, a = signal.sos2tf(sos)
+        assert is_1d_array(b)
+        assert is_1d_array(a)
+        assert is_float64_array(b)
+        assert is_float64_array(a)
+        return cls(b=b, a=a, sample_rate=sample_rate)
 
     @property
     def sos(self) -> SosCoeff:

--- a/src/lupy/filters.py
+++ b/src/lupy/filters.py
@@ -43,7 +43,7 @@ class Coeff:
         assert is_1d_array(a)
         assert is_float64_array(b)
         assert is_float64_array(a)
-        return cls(b=b, a=a, sample_rate=sample_rate)
+        return cls(b=b, a=a, _sos=sos, sample_rate=sample_rate)
 
     @property
     def sos(self) -> SosCoeff:

--- a/src/lupy/filters.py
+++ b/src/lupy/filters.py
@@ -248,6 +248,13 @@ class Filter(BaseFilter[Coeff]):
         zi = signal.sosfilt_zi(coeff.sos)
         zi[...] = 0
         sos_zi = np.repeat(np.expand_dims(zi, axis=1), num_channels, axis=1)
+
+        # Make sos_zi contiguous along the section axis so that
+        # :func:`.signalutils.sosfilt.sosfilt` can operate on it properly.
+        axis = 1 # num_channels axis
+        sos_zi = np.moveaxis(sos_zi, [0, axis + 1], [-2, -1])
+        sos_zi = np.ascontiguousarray(sos_zi)
+        sos_zi = np.moveaxis(sos_zi, [-2, -1], [0, axis + 1])
         self.sos_zi = _check_sos_zi(sos_zi, num_channels)
 
     def _sos(self, x: Float1dArray|Float2dArray) -> Float2dArray:


### PR DESCRIPTION
### TL;DR

Added methods to combine filter coefficients and improved filter initialization for better performance.

### What changed?

- Added `from_sos()` class method to `Coeff` to create a coefficient instance from second-order sections
- Implemented `combine()` method in `Coeff` to merge two filter coefficients
- Modified `FilterGroup` to automatically combine multiple coefficients into a single filter for better performance
- Fixed memory layout of `sos_zi` in `Filter.__init__()` to ensure proper contiguous arrays for the `sosfilt` function
- Added imports for `is_1d_array` and `is_float64_array` type utilities

### How to test?

- Create multiple `Coeff` instances and test the `combine()` method to ensure it properly merges filter coefficients
- Verify that `FilterGroup` with multiple coefficients now creates a single filter
- Test the `from_sos()` method by converting coefficients to SOS and back
- Benchmark filter performance before and after the memory layout optimization

### Why make this change?

These changes improve filter performance by combining multiple filters into a single one, reducing computational overhead. The memory layout optimization ensures that the filter state is properly aligned for efficient processing. The new methods also provide more flexibility when working with filter coefficients, allowing for easier manipulation and combination of filters.