### PR TITLE
Use generic channel count types in sampling and filter modules

### DIFF
--- a/src/lupy/meter.py
+++ b/src/lupy/meter.py
@@ -51,16 +51,16 @@ class Meter(Generic[NumChannelsT]):
     num_channels: NumChannelsT
     """Number of audio channels"""
 
-    sampler: Sampler
+    sampler: Sampler[NumChannelsT]
     """The :class:`~.sampling.Sampler` instance to buffer input data"""
 
-    true_peak_sampler: TruePeakSampler
+    true_peak_sampler: TruePeakSampler[NumChannelsT]
     """Sample buffer to hold un-filtered samples for :attr:`true_peak_processor`"""
 
-    processor: BlockProcessor
+    processor: BlockProcessor[NumChannelsT]
     """The :class:`~.processing.BlockProcessor` to perform the calulations"""
 
-    true_peak_processor: TruePeakProcessor
+    true_peak_processor: TruePeakProcessor[NumChannelsT]
     """The :class:`~.processing.TruePeakProcessor`"""
 
     sample_rate: int

--- a/src/lupy/signalutils/resample.py
+++ b/src/lupy/signalutils/resample.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
-from typing import NamedTuple, cast
+from typing import Generic, NamedTuple, cast
 import math
 
 import numpy as np
 from scipy.signal import firwin
 from scipy.signal._upfirdn_apply import _output_len, _apply, mode_enum
 
-from ..types import Float1dArray, Float2dArray
+from ..types import Float1dArray, Float2dArray, NumChannelsT
 from ..typeutils import ensure_1d_array, ensure_2d_array
 
 
@@ -105,7 +105,7 @@ def calc_resample_poly_params(
     )
 
 
-class ResamplePoly:
+class ResamplePoly(Generic[NumChannelsT]):
     """Polyphase resampler using FIR window
 
     Precomputes parameters for efficient repeated resampling.
@@ -123,7 +123,7 @@ class ResamplePoly:
         self,
         up: int,
         down: int,
-        num_channels: int,
+        num_channels: NumChannelsT,
         window: Float1dArray,
         num_input_samples: int = DEFAULT_INPUT_SAMPLES,
     ) -> None:
@@ -152,7 +152,7 @@ class ResamplePoly:
         )
 
     @property
-    def num_channels(self) -> int:
+    def num_channels(self) -> NumChannelsT:
         """Number of channels"""
         return self._num_channels
 
@@ -187,12 +187,12 @@ class ResamplePoly:
         return self.params.n_out
 
     @property
-    def input_shape(self) -> tuple[int, int]:
+    def input_shape(self) -> tuple[NumChannelsT, int]:
         """Expected input shape for :meth:`apply`"""
         return (self.num_channels, self.num_input_samples)
 
     @property
-    def output_shape(self) -> tuple[int, int]:
+    def output_shape(self) -> tuple[NumChannelsT, int]:
         """Output shape for :meth:`apply`"""
         return (self.num_channels, self.num_output_samples)
 
@@ -241,7 +241,7 @@ def _pad_h(h: Float1dArray, up: int) -> Float1dArray:
 # Adapted from:
 # https://github.com/scipy/scipy/blob/e29dcb65a2040f04819b426a04b60d44a8f69c04/scipy/signal/_upfirdn.py#L72-L104
 #
-class _UpFIRDn:
+class _UpFIRDn(Generic[NumChannelsT]):
     """Helper for resampling."""
     mode = mode_enum('constant')
     dtype = np.dtype(np.float64)
@@ -251,7 +251,7 @@ class _UpFIRDn:
         h: Float1dArray,
         up: int,
         down: int,
-        input_shape: tuple[int, int]
+        input_shape: tuple[NumChannelsT, int]
     ) -> None:
         if h.ndim != 1 or h.size == 0:
             raise ValueError('h must be 1-D with non-zero length')


### PR DESCRIPTION
### TL;DR

Added generic type parameter `NumChannelsT` to filter, sampler, and resampler classes to improve type safety for the number of audio channels.

### What changed?

- Added `NumChannelsT` as a second generic type parameter to `BaseFilter`, `TruePeakFilter`, `Filter`, and `FilterGroup` classes
- Made `FilterGroup` inherit from `Generic[NumChannelsT]`
- Updated all sampler classes (`BaseSampler`, `Sampler`, `TruePeakSampler`, `ThreadSafeSampler`, `ThreadSafeTruePeakSampler`) to be generic over `NumChannelsT`
- Added generic typing to resampling classes (`ResamplePoly`, `_UpFIRDn`)
- Updated `Meter` class attributes to use properly typed generic versions of samplers and processors
- Removed default value of `num_channels=1` from constructor parameters, making it a required argument
- Updated property and method return types to use `NumChannelsT` instead of `int` where appropriate

### How to test?

Run existing unit tests to ensure type annotations don't break functionality. Test with different channel configurations (mono, stereo, multi-channel) to verify the generic typing works correctly across all filter and sampler classes.

### Why make this change?

This change improves type safety by making the number of channels a generic type parameter, allowing for better compile-time type checking and more precise type hints. It ensures that channel count information is preserved through the type system, making the API more robust and easier to use correctly.