### PR TITLE
Slice updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,8 @@ exclude = ["tests*"]
 
 
 [tool.pytest.ini_options]
-addopts = "-n auto --dist=worksteal"
-testpaths = ["tests"]
+addopts = "-n auto --dist=worksteal --doctest-modules"
+testpaths = ["tests", "src"]
 
 [dependency-groups]
 test = [

--- a/src/lupy/sampling.py
+++ b/src/lupy/sampling.py
@@ -114,7 +114,7 @@ class Slice:
         return self._index
     @index.setter
     def index(self, value: int):
-        if value > self.max_index:
+        if value > self.max_index and self.overlap == 0:
             value = 0
         if value == self._index:
             return

--- a/src/lupy/sampling.py
+++ b/src/lupy/sampling.py
@@ -75,6 +75,38 @@ class Slice:
         :attr:`overlap` refers to the number of elements to repeat between
         chunks (what would typically be called "step size").
 
+
+    Examples:
+
+        Overlapping Slices:
+
+        >>> arr = np.arange(6)
+        >>> sl = Slice(step=4, overlap=2, max_index=0)
+        >>> sl.slice(arr, axis=0)       # index 0
+        array([0, 1, 2, 3])
+        >>> sl.increment(arr, axis=0)   # index 1
+        >>> sl.slice(arr, axis=0)
+        array([2, 3, 4, 5])
+        >>> sl.increment(arr, axis=0)
+        >>> sl.slice(arr, axis=0)       # index 2 (wraps around)
+        array([4, 5, 0, 1])
+        >>> sl.increment(arr, axis=0)
+        >>> sl.slice(arr, axis=0)       # index 0
+        array([0, 1, 2, 3])
+
+
+        Non-overlapping Slices:
+
+        >>> sl = Slice(step=3, overlap=0, max_index=1)
+        >>> sl.slice(arr, axis=0)       # index 0
+        array([0, 1, 2])
+        >>> sl.increment(arr, axis=0)
+        >>> sl.slice(arr, axis=0)       # index 1
+        array([3, 4, 5])
+        >>> sl.increment(arr, axis=0)
+        >>> sl.slice(arr, axis=0)       # index 0 (wraps around)
+        array([0, 1, 2])
+
     """
     step: int
     """Length of each sliced array chunk

--- a/src/lupy/sampling.py
+++ b/src/lupy/sampling.py
@@ -53,6 +53,29 @@ class BufferShape(NamedTuple):
 
 
 class Slice:
+    """Helper class to manage slicing of overlapping array chunks
+
+    This can be used to slice overlapping or non-overlapping chunks
+    from an array, wrapping around the end of the array as needed.
+
+    For non-overlapping slices, set :attr:`overlap` to zero.
+
+    Arguments:
+        step: Length of each sliced array chunk
+        overlap: Number of elements to repeat for each sliced array chunk
+        max_index: Maximum index value before wrapping to zero
+        index_: Initial index value (default 0)
+
+
+    .. note::
+
+        The naming of :attr:`step` and :attr:`overlap` is somewhat
+        counter-intuitive.  :attr:`step` refers to the length of each
+        sliced chunk (what would typically be called "window size"), while
+        :attr:`overlap` refers to the number of elements to repeat between
+        chunks (what would typically be called "step size").
+
+    """
     step: int
     """Length of each sliced array chunk
     (this would be better named "win_size")
@@ -61,6 +84,15 @@ class Slice:
     overlap: int
     """Number of elements to repeat for each sliced array chunk
     (this would be better named "step")
+    """
+
+    max_index: int
+    """Maximum :attr:`index` value before wrapping to zero when :attr:`overlap` is zero.
+
+    .. note::
+
+        This has no effect when :attr:`overlap` is non-zero, since the slice will
+        wrap around the end of the array as needed regardless of the index value.
     """
     def __init__(
         self,
@@ -78,6 +110,7 @@ class Slice:
 
     @property
     def index(self) -> int:
+        """The current index value"""
         return self._index
     @index.setter
     def index(self, value: int):
@@ -91,6 +124,7 @@ class Slice:
 
     @property
     def start_index(self) -> int:
+        """The starting index of the current slice"""
         ix = self._start_index
         if ix is None:
             ix = self._start_index = self.index * self.overlap
@@ -100,12 +134,20 @@ class Slice:
 
     @property
     def end_index(self) -> int:
+        """The ending index of the current slice"""
         ix = self._end_index
         if ix is None:
             ix = self._end_index = self.start_index + self.step
         return ix
 
     def increment(self, x: AnyArray, axis: int) -> None:
+        """Increment the slice to the next position, wrapping around the end
+        of the array as needed
+
+        Arguments:
+            x: The array being sliced
+            axis: The axis along which to slice
+        """
         if self.index == 0:
             self.index += 1
             return
@@ -118,14 +160,32 @@ class Slice:
             self._end_index = None
 
     def is_wrapped(self, x: AnyArray, axis: int) -> bool:
+        """Whether the current slice wraps around the end of the array
+
+        Arguments:
+            x: The array being sliced
+            axis: The axis along which to slice
+        """
         return self.end_index > x.shape[axis]
 
     def indices(self, arr_len: int) -> IndexArray:
+        """Get an index array for the current slice, wrapping around
+        the end of the array as needed
+
+        Arguments:
+            arr_len: Length of the array being sliced
+        """
         a = np.arange(self.step, dtype=np.intp) + self.start_index
         a[a>=arr_len] -= arr_len
         return a
 
-    def _calc_shape(self, x: AnyArray, axis: int):
+    def calc_shape(self, x: AnyArray, axis: int) -> tuple[int, ...]:
+        """Calculate the shape of the sliced array along the specified axis
+
+        Arguments:
+            x: The array being sliced
+            axis: The axis along which to slice
+        """
         ndim = x.ndim
         if axis == ndim - 1:
             new_shape = list(x.shape[:-1])
@@ -137,7 +197,17 @@ class Slice:
             del new_shape[axis + 1]
         return tuple(new_shape)
 
-    def _build_slice_array(self, x: AnyArray, axis: int):
+    def build_slice_array(self, x: AnyArray, axis: int) -> tuple[slice|IndexArray, ...]:
+        """Build a tuple of slices/indices for slicing the array along
+        the specified axis
+
+        If the slice wraps around the end of the array, an index array
+        will be used for that axis.  Otherwise, a standard slice will be used.
+
+        Arguments:
+            x: The array being sliced
+            axis: The axis along which to slice
+        """
         start_ix: int|None
         start_ix, end_ix = self.start_index, self.end_index
         if start_ix == 0:
@@ -154,8 +224,14 @@ class Slice:
         return tuple(sl_arr)
 
     def slice(self, x: AnyArray, axis: int) -> AnyArray:
-        sl_arr = self._build_slice_array(x, axis)
-        new_shape = self._calc_shape(x, axis)
+        """Get the current slice of the array along the specified axis
+
+        Arguments:
+            x: The array being sliced
+            axis: The axis along which to slice
+        """
+        sl_arr = self.build_slice_array(x, axis)
+        new_shape = self.calc_shape(x, axis)
         return np.reshape(x[sl_arr], new_shape)
 
     def __repr__(self) -> str:

--- a/src/lupy/sampling.py
+++ b/src/lupy/sampling.py
@@ -127,7 +127,10 @@ class Slice:
         """The starting index of the current slice"""
         ix = self._start_index
         if ix is None:
-            ix = self._start_index = self.index * self.overlap
+            if self.overlap != 0:
+                ix = self._start_index = self.index * self.overlap
+            else:
+                ix = self._start_index = self.index * self.step
             if ix < 0:
                 ix = 0
         return ix
@@ -151,7 +154,10 @@ class Slice:
         if self.index == 0:
             self.index += 1
             return
-        start_ix = self.start_index + self.overlap
+        if self.overlap != 0:
+            start_ix = self.start_index + self.overlap
+        else:
+            start_ix = self.start_index + self.step
         if start_ix >= x.shape[axis]:
             self.index = 0
         else:

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -3,9 +3,128 @@ from __future__ import annotations
 import pytest
 import numpy as np
 
-from lupy.sampling import Sampler, TruePeakSampler, calc_buffer_length
+from lupy.sampling import Sampler, TruePeakSampler, calc_buffer_length, Slice
 
-# def test_slice():
+
+
+def test_slice_non_overlap():
+    src_array_shape = (2, 48000)
+    chunk_size = 1000
+    overlap = 0
+    num_chunks = src_array_shape[1] // chunk_size
+    assert src_array_shape[1] % chunk_size == 0
+
+    src_array = np.zeros(src_array_shape, dtype=int)
+    src_array[0, :] = np.arange(src_array_shape[1])
+    src_array[1, :] = np.arange(src_array_shape[1]) * 10
+    expected_array = np.reshape(src_array, (2, num_chunks, chunk_size))
+
+    slc = Slice(
+        step=chunk_size,
+        max_index=num_chunks-1,
+        overlap=overlap,
+    )
+
+    assert slc.calc_shape(src_array, axis=1) == (2, chunk_size)
+
+    for i in range(num_chunks):
+        assert slc.index == i
+        assert not slc.is_wrapped(src_array, axis=1)
+        chunk = slc.slice(src_array, axis=1)
+        assert chunk.shape == (2, chunk_size)
+        assert np.array_equal(chunk, expected_array[:, i, :])
+        slc.increment(src_array, axis=1)
+
+    assert slc.index == 0
+    chunk = slc.slice(src_array, axis=1)
+    assert chunk.shape == (2, chunk_size)
+    assert np.array_equal(chunk, expected_array[:, 0, :])
+
+
+def test_slice_with_overlap():
+    N = 48000
+    src_array_shape = (2, N)
+    chunk_size = 1000
+    overlap_pct = 0.75
+    step = 1 - overlap_pct
+    step_count = int(step * chunk_size)
+
+    def get_chunk_indices(j: int) -> tuple[int, int]:
+        start_ix = int(chunk_size * (j * step))
+        end_ix = int(chunk_size * (j * step + 1))
+        return start_ix, end_ix
+
+    # j \in 0, 1, \ldots, \frac{N - chunk\_size}{chunk\_size \cdot step}
+    num_chunks = int(np.floor((N - chunk_size) / (chunk_size * step))) + 1
+
+    src_array = np.zeros(src_array_shape, dtype=int)
+    src_array[0, :] = np.arange(src_array_shape[1])
+    src_array[1, :] = np.arange(src_array_shape[1]) * 10
+
+    expected_array = np.zeros((2, num_chunks, chunk_size), dtype=int)
+    for i in range(num_chunks):
+        start_ix, end_ix = get_chunk_indices(i)
+        values = np.arange(start_ix, end_ix)
+
+        expected_array[0, i, :] = values
+        expected_array[1, i, :] = values * 10
+
+    slc = Slice(
+        step=chunk_size,
+        max_index=0,
+        overlap=step_count,
+    )
+
+    assert slc.calc_shape(src_array, axis=1) == (src_array_shape[0], chunk_size)
+
+    for i in range(num_chunks):
+        start_ix, end_ix = get_chunk_indices(i)
+        assert slc.index == i
+        if slc.end_index > src_array.shape[1]:
+            assert slc.is_wrapped(src_array, axis=1)
+        else:
+            assert not slc.is_wrapped(src_array, axis=1)
+            assert slc.start_index == start_ix
+            assert slc.end_index == end_ix
+        chunk = slc.slice(src_array, axis=1)
+        assert chunk.shape == (src_array_shape[0], chunk_size)
+        assert np.array_equal(chunk, expected_array[:, i, :])
+        slc.increment(src_array, axis=1)
+
+    assert end_ix == src_array.shape[1]
+    i = num_chunks
+    real_i = num_chunks
+    wrap_completed = False
+    while i < num_chunks * 2:
+        start_ix, end_ix = get_chunk_indices(i)
+        is_wrapped = start_ix < src_array.shape[1] and end_ix > src_array.shape[1]
+        assert slc.is_wrapped(src_array, axis=1) == is_wrapped
+        if is_wrapped:
+            if wrap_completed:
+                break
+            assert slc.index == i
+            chunk_start = src_array[:, start_ix:]
+            chunk_end = src_array[:, :end_ix % src_array.shape[1]]
+            chunk_expected = np.concatenate((chunk_start, chunk_end), axis=1)
+        else:
+            if not wrap_completed:
+                real_i = 0
+                wrap_completed = True
+            start_ix, end_ix = get_chunk_indices(real_i)
+            assert slc.index == real_i
+            chunk_expected = expected_array[:, real_i, :]
+
+        assert slc.start_index == start_ix
+        assert slc.end_index == end_ix
+        chunk = slc.slice(src_array, axis=1)
+        assert chunk.shape == (src_array_shape[0], chunk_size)
+        assert np.array_equal(chunk, chunk_expected)
+
+        slc.increment(src_array, axis=1)
+        i += 1
+        real_i += 1
+
+    assert wrap_completed
 
 
 


### PR DESCRIPTION
### TL;DR

Added comprehensive documentation and doctests to the `Slice` class and enabled doctest execution in pytest configuration.

### What changed?

- Added detailed docstring to the `Slice` class with usage examples for both overlapping and non-overlapping slices
- Added docstrings to all `Slice` class properties and methods explaining their purpose and parameters
- Fixed the `index` setter to only wrap to zero when `overlap` is zero
- Updated `start_index` property to handle both overlapping and non-overlapping cases correctly
- Updated `increment` method to use appropriate step calculation based on overlap value
- Renamed private methods `_calc_shape` and `_build_slice_array` to public methods `calc_shape` and `build_slice_array`
- Added comprehensive test cases for both non-overlapping and overlapping slice scenarios
- Enabled doctest execution by adding `--doctest-modules` to pytest options and including `src` in test paths

### How to test?

Run `pytest` to execute both the new unit tests and the doctests embedded in the `Slice` class documentation. The doctests demonstrate basic usage patterns while the unit tests provide comprehensive coverage of edge cases and wrapping behavior.

### Why make this change?

The `Slice` class lacked proper documentation making it difficult to understand its purpose and usage patterns. The doctests provide executable examples that serve as both documentation and tests, while the comprehensive unit tests ensure the class behaves correctly in various scenarios including array wrapping and different overlap configurations.