### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v6
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "numpy<=2.4.4",


### PR DESCRIPTION
### TL;DR

Added Python 3.14 support to the project

### What changed?

- Added Python 3.14 to the test matrix in both test jobs within the GitHub Actions workflow
- Added Python 3.13 and 3.14 classifiers to the pyproject.toml file

### How to test?

The GitHub Actions workflow will now automatically test against Python 3.14 when it runs. You can also manually test by running the test suite with Python 3.14 locally if available.

### Why make this change?

This ensures the project is compatible with the latest Python version and provides users with confidence that the package works on Python 3.14. It also keeps the project current with Python's release cycle.