### PR TITLE
Add workflow to test sdist and wheels

### DIFF
--- a/.github/workflows/dist-test.yml
+++ b/.github/workflows/dist-test.yml
@@ -69,13 +69,13 @@ jobs:
     - name: Install wheel
       run: pip install dist/*.whl
     - name: Test built wheel
-      run: py.test
+      run: py.test -n=0 tests/test_distribution.py
     - name: Install sdist
       run: |
         pip uninstall -y lupy
         pip install dist/*.tar.gz
     - name: Test built sdist
-      run: py.test
+      run: py.test -n=0 tests/test_distribution.py
 
   deploy:
     needs: test

--- a/.github/workflows/dist-test.yml
+++ b/.github/workflows/dist-test.yml
@@ -47,6 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        dist-type: ["wheel", "sdist"]
 
     steps:
     - uses: actions/checkout@v6
@@ -68,13 +69,11 @@ jobs:
         path: dist
     - name: Install wheel
       run: pip install dist/*.whl
-    - name: Test built wheel
-      run: py.test -n=0 tests/test_distribution.py
+      if: matrix.dist-type == 'wheel'
     - name: Install sdist
-      run: |
-        pip uninstall -y lupy
-        pip install dist/*.tar.gz
-    - name: Test built sdist
+      run: pip install dist/*.tar.gz
+      if: matrix.dist-type == 'sdist'
+    - name: Test built distribution
       run: py.test -n=0 tests/test_distribution.py
 
   deploy:

--- a/.github/workflows/dist-test.yml
+++ b/.github/workflows/dist-test.yml
@@ -1,0 +1,93 @@
+
+name: Test from sdist and wheels
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      allow_deploy:
+        description: "Deploy to PyPI"
+        required: true
+        type: boolean
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.14
+      - name: Build dists
+        run: uv build
+      - name: Export Lockfile
+        run: uv export --frozen --only-group test --only-group doc --format requirements-txt -o requirements.txt
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: 'dists'
+          path: 'dist/*'
+      - name: Upload requirements
+        uses: actions/upload-artifact@v7
+        with:
+          name: 'requirements'
+          path: 'requirements.txt'
+
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Download requirements
+      uses: actions/download-artifact@v8
+      with:
+        name: 'requirements'
+    - name: Install dependencies
+      run: pip install -r requirements.txt
+
+    - name: Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: 'dists'
+        path: dist
+    - name: Install wheel
+      run: pip install dist/*.whl
+    - name: Test built wheel
+      run: py.test
+    - name: Install sdist
+      run: |
+        pip uninstall -y lupy
+        pip install dist/*.tar.gz
+    - name: Test built sdist
+      run: py.test
+
+  deploy:
+    needs: test
+    if: ${{ success() && inputs.allow_deploy }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: 'dists'
+          path: dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -1,0 +1,12 @@
+# A simple test to ensure that the distribution can be installed and imported.
+
+
+def test_import():
+    from lupy import Meter, Sampler, BlockProcessor, TruePeakProcessor
+    assert Meter is not None
+    assert Sampler is not None
+    assert BlockProcessor is not None
+    assert TruePeakProcessor is not None
+
+    meter = Meter(block_size=128, num_channels=2, sample_rate=48000)
+    assert meter is not None


### PR DESCRIPTION
### TL;DR

Added GitHub Actions workflow for testing package distributions and optional PyPI deployment

### What changed?

- Created `.github/workflows/dist-test.yml` workflow that builds source distributions and wheels, tests them across Python versions 3.10-3.14, and optionally deploys to PyPI
- Added `tests/test_distribution.py` with basic import and instantiation tests for the `lupy` package components

### How to test?

The workflow automatically runs on pushes and pull requests to the main branch. To test PyPI deployment, manually trigger the workflow with the "Deploy to PyPI" option enabled. The distribution test verifies that `Meter`, `Sampler`, `BlockProcessor`, and `TruePeakProcessor` can be imported and instantiated correctly.

### Why make this change?

This ensures that both wheel and source distributions work correctly across all supported Python versions before release, and provides an automated deployment pipeline to PyPI when needed.