### PR TITLE
Workflow cleanup

### DIFF
--- a/.github/workflows/dist-test.yml
+++ b/.github/workflows/dist-test.yml
@@ -4,8 +4,16 @@ name: Test from sdist and wheels
 on:
   push:
     branches: [ main ]
+    paths:
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/dist-test.yml"
   pull_request:
     branches: [ main ]
+    paths:
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/dist-test.yml"
   workflow_dispatch:
     inputs:
       allow_deploy:

--- a/.github/workflows/dist-test.yml
+++ b/.github/workflows/dist-test.yml
@@ -58,31 +58,31 @@ jobs:
         dist-type: ["wheel", "sdist"]
 
     steps:
-    - uses: actions/checkout@v6
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Download requirements
-      uses: actions/download-artifact@v8
-      with:
-        name: 'requirements'
-    - name: Install dependencies
-      run: pip install -r requirements.txt
+      - uses: actions/checkout@v6
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Download requirements
+        uses: actions/download-artifact@v8
+        with:
+          name: 'requirements'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
 
-    - name: Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: 'dists'
-        path: dist
-    - name: Install wheel
-      run: pip install dist/*.whl
-      if: matrix.dist-type == 'wheel'
-    - name: Install sdist
-      run: pip install dist/*.tar.gz
-      if: matrix.dist-type == 'sdist'
-    - name: Test built distribution
-      run: py.test -n=0 tests/test_distribution.py
+      - name: Download artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: 'dists'
+          path: dist
+      - name: Install wheel
+        run: pip install dist/*.whl
+        if: matrix.dist-type == 'wheel'
+      - name: Install sdist
+        run: pip install dist/*.tar.gz
+        if: matrix.dist-type == 'sdist'
+      - name: Test built distribution
+        run: py.test -n=0 tests/test_distribution.py
 
   deploy:
     needs: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,7 @@ jobs:
       - name: Run type checks
         run: uv run mypy
 
-  build:
-
+  test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,20 @@ name: Test
 on:
   push:
     branches: [ "main" ]
+    paths:
+      - "pyproject.toml"
+      - "uv.lock"
+      - "src/**"
+      - "tests/**"
+      - ".github/workflows/test.yml"
   pull_request:
     branches: [ "main" ]
+    paths:
+      - "pyproject.toml"
+      - "uv.lock"
+      - "src/**"
+      - "tests/**"
+      - ".github/workflows/test.yml"
 
 jobs:
   typecheck:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,15 +28,15 @@ jobs:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v6
-    - name: Install uv and set the python version
-      uses: astral-sh/setup-uv@v7
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install the Project
-      run: uv sync --frozen --no-dev --group test
-    - name: Run type checks
-      run: uv run mypy
+      - uses: actions/checkout@v6
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install the Project
+        run: uv sync --frozen --no-dev --group test
+      - name: Run type checks
+        run: uv run mypy
 
   build:
 
@@ -47,12 +47,12 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v6
-    - name: Install uv and set the python version
-      uses: astral-sh/setup-uv@v7
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install the Project
-      run: uv sync --frozen --no-dev --group test
-    - name: Test with pytest
-      run: uv run py.test
+      - uses: actions/checkout@v6
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install the Project
+        run: uv sync --frozen --no-dev --group test
+      - name: Test with pytest
+        run: uv run py.test


### PR DESCRIPTION
### TL;DR

Optimized GitHub Actions workflows to run only when relevant files change and improved YAML formatting consistency.

### What changed?

Added path filters to both `dist-test.yml` and `test.yml` workflows to trigger only when specific files are modified:
- `dist-test.yml` now runs only when `pyproject.toml`, `uv.lock`, or the workflow file itself changes
- `test.yml` now runs only when `pyproject.toml`, `uv.lock`, source code (`src/**`), tests (`tests/**`), or the workflow file changes

Also standardized YAML indentation across both workflow files and renamed the `build` job to `test` in the test workflow for clarity.

### How to test?

1. Make changes to files not in the path filters (like documentation) and verify workflows don't trigger
2. Make changes to files in the path filters (like `pyproject.toml` or source code) and verify workflows trigger as expected
3. Confirm all existing functionality works by running the workflows manually via workflow_dispatch

### Why make this change?

This optimization reduces unnecessary CI runs, saving compute resources and providing faster feedback by only running tests when code or configuration that could affect the build/test results has actually changed. The formatting improvements make the workflow files more consistent and easier to read.