### PR TITLE
Adjust actions caching

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/dist-test.yml
+++ b/.github/workflows/dist-test.yml
@@ -59,15 +59,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      - name: Download requirements
+        uses: actions/download-artifact@v8
+        with:
+          name: 'requirements'
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
-      - name: Download requirements
-        uses: actions/download-artifact@v8
-        with:
-          name: 'requirements'
       - name: Install dependencies
         run: pip install -r requirements.txt
 

--- a/.github/workflows/dist-test.yml
+++ b/.github/workflows/dist-test.yml
@@ -63,6 +63,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
       - name: Download requirements
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
+          enable-cache: true
       - name: Install the Project
         run: uv sync --frozen --no-dev --group test
       - name: Run type checks
@@ -51,6 +52,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
+          enable-cache: true
       - name: Install the Project
         run: uv sync --frozen --no-dev --group test
       - name: Test with pytest


### PR DESCRIPTION
### TL;DR

Enabled caching for uv and pip package managers in GitHub Actions workflows to improve build performance.

### What changed?

- Added `enable-cache: true` to all `astral-sh/setup-uv@v7` action configurations in codspeed.yml and test.yml workflows
- Added `cache: "pip"` to the `actions/setup-python@v6` action in dist-test.yml workflow
- Reordered steps in dist-test.yml to download requirements before setting up Python to optimize cache usage

### How to test?

Run the GitHub Actions workflows and verify that:
- Build times are reduced on subsequent runs
- Cache hit/miss information appears in the workflow logs
- All existing functionality continues to work as expected

### Why make this change?

Caching package dependencies reduces workflow execution time by avoiding redundant downloads and installations of the same packages across workflow runs, leading to faster CI/CD feedback cycles.