### PR TITLE
Add convenience method to get latest measurement values

### DIFF
--- a/src/lupy/meter.py
+++ b/src/lupy/meter.py
@@ -5,7 +5,7 @@ from fractions import Fraction
 import numpy as np
 
 from .sampling import Sampler, TruePeakSampler
-from .processing import BlockProcessor, TruePeakProcessor
+from .processing import BlockProcessor, TruePeakProcessor, SILENCE_DB
 from .arraytypes import MeterArray, TruePeakArray
 from .types import *
 from .typeutils import is_2d_array, ensure_2d_array
@@ -269,6 +269,46 @@ class Meter(Generic[NumChannelsT]):
         dtype :obj:`~.arraytypes.MeterDtype`
         """
         return self.processor.block_data
+
+    @property
+    def current_measurement(self) -> CurrentMeasurement[NumChannelsT]:
+        """The current measurement values as a :class:`~.CurrentMeasurement` instance
+
+        This is a snapshot of the most recent measurement values for each metric
+        as of the last processed gating block.
+
+        It provides the latest values for:
+
+        - The measurement time for the last processed gating block
+        - The :attr:`momentary_lkfs`
+        - :attr:`short_term_lkfs`
+        - :attr:`integrated_lkfs`
+        - :attr:`lra`
+        - :attr:`true_peak_current`
+        - The maximum of the :attr:`true_peak_current` array
+
+
+        If no gating blocks have been processed yet, the values returned will
+        correspond to their initial silence states.
+
+        """
+        block_data = self.block_data
+        if block_data.size == 0:
+            m = s = SILENCE_DB
+            t = 0
+        else:
+            m = block_data['m'][-1]
+            s = block_data['s'][-1]
+            t = block_data['t'][-1]
+        return CurrentMeasurement(
+            momentary=m,
+            short_term=s,
+            integrated=self.integrated_lkfs,
+            lra=self.lra,
+            time=t,
+            true_peak_array=self.true_peak_current,
+            true_peak_max=self.true_peak_current.max(),
+        )
 
     @property
     def momentary_lkfs(self) -> Float1dArray:

--- a/src/lupy/meter.py
+++ b/src/lupy/meter.py
@@ -300,14 +300,15 @@ class Meter(Generic[NumChannelsT]):
             m = block_data['m'][-1]
             s = block_data['s'][-1]
             t = block_data['t'][-1]
+        tp_current = self.true_peak_current
         return CurrentMeasurement(
             momentary=m,
             short_term=s,
             integrated=self.integrated_lkfs,
             lra=self.lra,
             time=t,
-            true_peak_array=self.true_peak_current,
-            true_peak_max=self.true_peak_current.max(),
+            true_peak_array=tp_current,
+            true_peak_max=tp_current.max(),
         )
 
     @property

--- a/src/lupy/types.py
+++ b/src/lupy/types.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import TypeVar, Generic, Literal, NamedTuple, Any
+from typing import TypeVar, Generic, Literal, Any
 import sys
 if sys.version_info < (3, 11):
     from typing_extensions import TypeAlias
 else:
     from typing import TypeAlias
+from dataclasses import dataclass
 
 import numpy as np
 import numpy.typing as npt
@@ -84,7 +85,9 @@ SosZI = np.ndarray[tuple[int, int, Literal[2]], np.dtype[np.float64]]
 """Array representing initial conditions for second-order sections filtering"""
 
 
-class CurrentMeasurement(NamedTuple, Generic[NumChannelsT]):
+# TODO: Revert to NamedTuple when Python 3.10 support is dropped
+@dataclass(frozen=True)
+class CurrentMeasurement(Generic[NumChannelsT]):
     """Represents the current measurement state for a gating block"""
     time: float|Floating
     """The measurement time for this gating block"""

--- a/src/lupy/types.py
+++ b/src/lupy/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TypeVar, Generic, Literal, Any
+from typing import TypeVar, Generic, Literal, NamedTuple, Any
 import sys
 if sys.version_info < (3, 11):
     from typing_extensions import TypeAlias
@@ -17,7 +17,7 @@ __all__ = (
     'AnyArray', 'BoolArray', 'IndexArray', 'FloatArray', 'ComplexArray',
     'Float1dArray', 'Float2dArray', 'Float3dArray', 'Float2dArray32', 'AnyFloatArray',
     'AnyNdArray', 'Any1dArray', 'Any2dArray', 'Any3dArray', 'ShapeT',
-    'NumChannels', 'NumChannelsT',
+    'NumChannels', 'NumChannelsT', 'CurrentMeasurement',
 )
 
 NumChannels = Literal[1, 2, 3, 5]
@@ -82,3 +82,21 @@ SosCoeff = np.ndarray[tuple[int, Literal[6]], np.dtype[np.float64]]
 
 SosZI = np.ndarray[tuple[int, int, Literal[2]], np.dtype[np.float64]]
 """Array representing initial conditions for second-order sections filtering"""
+
+
+class CurrentMeasurement(NamedTuple, Generic[NumChannelsT]):
+    """Represents the current measurement state for a gating block"""
+    time: float|Floating
+    """The measurement time for this gating block"""
+    momentary: float|Floating
+    """The :term:`Momentary Loudness` for this gating block"""
+    short_term: float|Floating
+    """The :term:`Short-Term Loudness` for this gating block"""
+    integrated: float|Floating
+    """The :term:`Integrated Loudness` for this gating block"""
+    lra: float|Floating
+    """The :term:`Loudness Range` for this gating block"""
+    true_peak_array: np.ndarray[tuple[NumChannelsT], np.dtype[np.float64]]
+    """The :term:`True Peak` value for each channel for this gating block"""
+    true_peak_max: float|Floating
+    """The maximum :term:`True Peak` value across all channels for this gating block"""

--- a/src/lupy/types.py
+++ b/src/lupy/types.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
-from typing import TypeVar, Generic, Literal, NamedTuple, Any
+from typing import TypeVar, Generic, Literal, Any
 import sys
+if sys.version_info <= (3, 10):
+    from typing_extensions import NamedTuple
+else:
+    from typing import NamedTuple
 if sys.version_info < (3, 11):
     from typing_extensions import TypeAlias
 else:

--- a/src/lupy/types.py
+++ b/src/lupy/types.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
-from typing import TypeVar, Generic, Literal, Any
+from typing import TypeVar, Generic, Literal, NamedTuple, Any
 import sys
-if sys.version_info <= (3, 10):
-    from typing_extensions import NamedTuple
-else:
-    from typing import NamedTuple
 if sys.version_info < (3, 11):
     from typing_extensions import TypeAlias
 else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,14 +37,14 @@ def inc_samples():
     return gen
 
 @pytest.fixture
-def lkfs_1k_sine() -> Callable[[int, int, float], FloatArray]:
+def lkfs_1k_sine() -> Callable[[int, int, float|FloatArray], FloatArray]:
     # def gen(count: int, sample_rate: int, amp: float = 1):
     #     fc = 997
     #     t = np.arange(count) / sample_rate
     #     return amp * np.sin(2 * np.pi * fc * t)
     return gen_1k_sine
 
-def gen_1k_sine(count: int, sample_rate: int, amp: float = 1):
+def gen_1k_sine(count: int, sample_rate: int, amp: float|FloatArray = 1):
     fc = 997
     t = np.arange(count) / sample_rate
     return amp * np.sin(2 * np.pi * fc * t)

--- a/tests/test_meter_options.py
+++ b/tests/test_meter_options.py
@@ -51,6 +51,8 @@ def test_momentary_disabled():
     assert meter.true_peak_max != -np.inf
     tp_array = meter.true_peak_array['tp']
     assert not np.array_equal(tp_array, np.full_like(tp_array, -np.inf))
+    current_measurement = meter.current_measurement
+    assert current_measurement.momentary == 0.0
 
 
 def test_short_term_disabled_and_lra_enabled_raises():
@@ -97,6 +99,8 @@ def test_short_term_disabled():
     assert meter.true_peak_max != -np.inf
     tp_array = meter.true_peak_array['tp']
     assert not np.array_equal(tp_array, np.full_like(tp_array, -np.inf))
+    current_measurement = meter.current_measurement
+    assert current_measurement.short_term == 0.0
 
 
 def test_lra_disabled():
@@ -124,6 +128,8 @@ def test_lra_disabled():
     assert meter.true_peak_max != -np.inf
     tp_array = meter.true_peak_array['tp']
     assert not np.array_equal(tp_array, np.full_like(tp_array, -np.inf))
+    current_measurement = meter.current_measurement
+    assert current_measurement.lra == 0.0
 
 
 def test_true_peak_disabled():
@@ -149,3 +155,6 @@ def test_true_peak_disabled():
     assert meter.true_peak_max == -np.inf
     tp_array = meter.true_peak_array['tp']
     assert np.array_equal(tp_array, np.full_like(tp_array, -np.inf))
+    current_measurement = meter.current_measurement
+    assert current_measurement.true_peak_max == -np.inf
+    assert np.all(current_measurement.true_peak_array == -np.inf)

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -192,6 +192,75 @@ def test_bs2217_compliance_cases(bs_2217_compliance_case):
     assert lufs - tol <= integrated <= lufs + tol
 
 
+def test_meter_current_measurement(all_channels):
+    num_channels, sine_channel = all_channels
+    silent_channels_ix = np.array(
+        [i for i in range(num_channels) if i != sine_channel],
+        dtype=np.intp,
+    )
+
+    sample_rate = 48000
+    block_size = 128
+    meter = Meter(
+        block_size=block_size,
+        num_channels=num_channels,
+        sample_rate=sample_rate,
+    )
+
+    N = sample_rate * 2
+    assert N % block_size == 0
+
+    # generate a linearly increasing amplitude array from -18 dBFS to 0 dBFS
+    amp_array = np.linspace(10 ** (-18/20), 1.0, N, dtype=np.float64)
+    src_data = build_samples(
+        num_samples=N,
+        num_channels=num_channels,
+        sample_rate=sample_rate,
+        sine_channels=(sine_channel,),
+        sine_amp=amp_array,
+    )
+
+    num_blocks = N // block_size
+    src_data = np.reshape(src_data, (num_channels, num_blocks, block_size))
+
+    # Check that the initial current measurement is at the expected silence state
+    current_measurement = meter.current_measurement
+    assert current_measurement.momentary == SILENCE_DB
+    assert current_measurement.short_term == SILENCE_DB
+    assert current_measurement.integrated == meter.integrated_lkfs == SILENCE_DB
+    assert current_measurement.lra == meter.lra == 0
+    assert current_measurement.time == 0
+    assert np.all(current_measurement.true_peak_array == -np.inf)
+    assert current_measurement.true_peak_max == -np.inf
+
+
+    write_index = 0
+    gate_block_index = 0
+    prev_measurement: CurrentMeasurement|None = None
+
+    for i in range(num_blocks):
+        block = src_data[:, i, :]
+        meter.write(block, process=False)
+        while meter.can_process():
+            meter.process()
+            current_measurement = meter.current_measurement
+
+            assert current_measurement.time == pytest.approx(gate_block_index * 0.1)
+            if prev_measurement is not None:
+                assert current_measurement.integrated >= prev_measurement.integrated
+                assert current_measurement.time > prev_measurement.time
+                assert current_measurement.momentary >= prev_measurement.momentary
+                assert current_measurement.short_term >= prev_measurement.short_term
+                assert current_measurement.lra >= prev_measurement.lra
+                assert current_measurement.true_peak_max >= prev_measurement.true_peak_max
+                assert np.all(current_measurement.true_peak_array >= prev_measurement.true_peak_array)
+                assert np.all(current_measurement.true_peak_array[silent_channels_ix] == -np.inf)
+
+            prev_measurement = current_measurement
+            gate_block_index += 1
+        write_index += 1
+
+
 def test_true_peak_gate_blocks(
     true_peak_gate_duration,
     sample_rate,

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from lupy import Meter
 from lupy.processing import SILENCE_DB
-from lupy.types import Float2dArray
+from lupy.types import FloatArray, Float2dArray
 
 from conftest import gen_1k_sine
 
@@ -22,7 +22,7 @@ def build_samples(
     num_channels: int,
     sample_rate: int,
     sine_channels: Iterable[int]|None,
-    sine_amp: float = 1,
+    sine_amp: float|FloatArray = 1,
 ) -> Float2dArray:
     samples = np.zeros((num_channels, num_samples), dtype=np.float64)
     if sine_channels is not None:


### PR DESCRIPTION
### TL;DR

Adds a `current_measurement` property to the `Meter` class that returns a snapshot of all loudness metrics at the most recent gating block.

### What changed?

A new `CurrentMeasurement` frozen dataclass was introduced in `types.py` to hold a snapshot of loudness metrics for a given gating block, including:
- `time` — the measurement time of the last processed gating block
- `momentary` — momentary loudness
- `short_term` — short-term loudness
- `integrated` — integrated loudness
- `lra` — loudness range
- `true_peak_array` — per-channel true peak values
- `true_peak_max` — maximum true peak across all channels

The `Meter` class exposes this via a new `current_measurement` property. When no gating blocks have been processed yet, the returned values reflect their initial silence states (e.g., `SILENCE_DB` for loudness values, `-inf` for true peak).

### How to test?

- Run the new `test_meter_current_measurement` test, which verifies that the initial silence state is correct and that all metrics monotonically increase as a linearly growing amplitude sine wave is processed block by block.
- Run the updated `test_meter_options.py` tests, which verify that disabled metrics (momentary, short-term, LRA, true peak) report their expected default values through `current_measurement`.

### Why make this change?

Previously, retrieving a consistent snapshot of all loudness metrics required calling multiple separate properties on the `Meter` instance. The `current_measurement` property provides a single, atomic snapshot of all metrics as of the last processed gating block, making it easier to consume measurement state in real-time or streaming use cases.