### PR TITLE
Doc updates

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -52,5 +52,5 @@ html_static_path = ['_static']
 intersphinx_mapping = {
     'python':('https://docs.python.org/', None),
     'numpy':('https://numpy.org/doc/stable/', None),
-    'scipy':('https://docs.scipy.org/doc/scipy-1.13.1/', None),
+    'scipy':('https://docs.scipy.org/doc/scipy/', None),
 }

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -63,15 +63,11 @@ Installation
 Pip
 ---
 
-Pip install not yet available since there is another project named "lupy" on
-the Python Package Index (PyPI).
+.. code-block:: bash
 
-Renaming and/or publishing to PyPI will hopefully come soon.
+  $ pip install lupy
 
 
-.. .. code-block:: bash
-
-..    $ pip install lupy
 
 
 Dependencies

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -83,6 +83,9 @@ Project Links
 Homepage
    :project-url:`Homepage`
 
+PyPI
+   :project-url:`PyPI`
+
 Documentation
    :project-url:`Documentation`
 

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -157,10 +157,10 @@ Scalar Values
 These attributes contain a single value which is updated
 each time the meter processes new samples.
 
-* :attr:`Meter.integrated_lkfs`
-* :attr:`Meter.lra`
+* :attr:`Meter.integrated_lkfs` holds the latest integrated loudness value.
+* :attr:`Meter.lra` holds the latest loudness range value.
 * :attr:`Meter.true_peak_current` holds the latest true peak values for each channel.
-* :attr:`Meter.true_peak_max`
+* :attr:`Meter.true_peak_max` holds the maximum true peak value observed across all channels.
 
 .. tip::
 

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -161,6 +161,14 @@ each time the meter processes new samples.
 * :attr:`Meter.lra`
 * :attr:`Meter.true_peak_max`
 
+.. tip::
+
+  For convenience, all relevant measurement values can be accessed together
+  through :attr:`Meter.current_measurement`. This returns an object containing
+  the items listed above as well as other useful measurements.
+
+  See the :class:`~.CurrentMeasurement` class reference for the full list.
+
 
 Array Values
 ^^^^^^^^^^^^

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -185,7 +185,7 @@ arrays will be one element larger (when accessed).
 Structured Arrays
 """""""""""""""""
 
-The historical :term:`Momentary Loudness`, :term:`Short-Term Loudness`
+The historical :term:`Momentary Loudness` and :term:`Short-Term Loudness`
 measurements can be accessed as a :term:`structured array` through :attr:`Meter.block_data`:
 
 >>> ms_times = meter.block_data['t']           # A 1D array of times in seconds

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -95,7 +95,7 @@ Channel Layout
 --------------
 
 When measuring more than one channel, the expected layout should follow
-the order below.  This is import because channels are weighted differently
+the order below.  This is important because channels are weighted differently
 in the calculations.
 
 

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -181,12 +181,36 @@ recent data point in their last element. In other words,
 when a new 100ms chunk of input has been processed, the
 arrays will be one element larger (when accessed).
 
-The time (in seconds) for each can be accessed from
-:attr:`Meter.t`
 
-* :attr:`Meter.momentary_lkfs`
-* :attr:`Meter.short_term_lkfs`
-* :attr:`Meter.true_peak_current`
+Structured Arrays
+"""""""""""""""""
+
+The historical :term:`Momentary Loudness`, :term:`Short-Term Loudness`
+measurements can be accessed as a :term:`structured array` through :attr:`Meter.block_data`:
+
+>>> ms_times = meter.block_data['t']           # A 1D array of times in seconds
+>>> momentary_values = meter.block_data['m']   # A 1D array of momentary loudness values
+>>> short_term_values = meter.block_data['s']  # A 1D array of short-term loudness values
+
+
+The historical :term:`True Peak` measurements can be accessed
+from :attr:`Meter.true_peak_array` which contains the peak values
+for each channel along with their measurement times:
+
+>>> tp_times = meter.true_peak_array['t']   # A 1D array of times in seconds
+>>> tp_values = meter.true_peak_array['tp'] # A 2D array of shape (n, num_channels)
+
+
+Direct Access
+"""""""""""""
+
+* :attr:`Meter.t` holds the times for momentary/short-term measurements.
+* :attr:`Meter.momentary_lkfs` holds the historical momentary loudness values.
+* :attr:`Meter.short_term_lkfs` holds the historical short-term loudness values.
+* :attr:`Meter.true_peak_current` holds the latest true peak values for each channel.
+
+
+
 
 
 

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -159,6 +159,7 @@ each time the meter processes new samples.
 
 * :attr:`Meter.integrated_lkfs`
 * :attr:`Meter.lra`
+* :attr:`Meter.true_peak_current` holds the latest true peak values for each channel.
 * :attr:`Meter.true_peak_max`
 
 .. tip::
@@ -207,7 +208,6 @@ Direct Access
 * :attr:`Meter.t` holds the times for momentary/short-term measurements.
 * :attr:`Meter.momentary_lkfs` holds the historical momentary loudness values.
 * :attr:`Meter.short_term_lkfs` holds the historical short-term loudness values.
-* :attr:`Meter.true_peak_current` holds the latest true peak values for each channel.
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/nocarryr/lupy"
 Documentation = "https://lupy-nocarryr.readthedocs.io/"
+PyPI = "https://pypi.org/project/lupy/"
 
 
 

--- a/src/lupy/meter.py
+++ b/src/lupy/meter.py
@@ -307,7 +307,7 @@ class Meter(Generic[NumChannelsT]):
             integrated=self.integrated_lkfs,
             lra=self.lra,
             time=t,
-            true_peak_array=tp_current,
+            true_peak_current=tp_current,
             true_peak_max=tp_current.max(),
         )
 

--- a/src/lupy/meter.py
+++ b/src/lupy/meter.py
@@ -279,7 +279,7 @@ class Meter(Generic[NumChannelsT]):
 
         It provides the latest values for:
 
-        - The measurement time for the last processed gating block
+        - The :attr:`measurement time <t>` for the last processed gating block
         - The :attr:`momentary_lkfs`
         - :attr:`short_term_lkfs`
         - :attr:`integrated_lkfs`

--- a/src/lupy/types.py
+++ b/src/lupy/types.py
@@ -99,7 +99,7 @@ class CurrentMeasurement(Generic[NumChannelsT]):
     """The :term:`Integrated Loudness` for this gating block"""
     lra: float|Floating
     """The :term:`Loudness Range` for this gating block"""
-    true_peak_array: np.ndarray[tuple[NumChannelsT], np.dtype[np.float64]]
+    true_peak_current: np.ndarray[tuple[NumChannelsT], np.dtype[np.float64]]
     """The :term:`True Peak` value for each channel for this gating block"""
     true_peak_max: float|Floating
     """The maximum :term:`True Peak` value across all channels for this gating block"""

--- a/tests/test_meter_options.py
+++ b/tests/test_meter_options.py
@@ -157,4 +157,4 @@ def test_true_peak_disabled():
     assert np.array_equal(tp_array, np.full_like(tp_array, -np.inf))
     current_measurement = meter.current_measurement
     assert current_measurement.true_peak_max == -np.inf
-    assert np.all(current_measurement.true_peak_array == -np.inf)
+    assert np.all(current_measurement.true_peak_current == -np.inf)

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -230,7 +230,7 @@ def test_meter_current_measurement(all_channels):
     assert current_measurement.integrated == meter.integrated_lkfs == SILENCE_DB
     assert current_measurement.lra == meter.lra == 0
     assert current_measurement.time == 0
-    assert np.all(current_measurement.true_peak_array == -np.inf)
+    assert np.all(current_measurement.true_peak_current == -np.inf)
     assert current_measurement.true_peak_max == -np.inf
 
 
@@ -253,8 +253,8 @@ def test_meter_current_measurement(all_channels):
                 assert current_measurement.short_term >= prev_measurement.short_term
                 assert current_measurement.lra >= prev_measurement.lra
                 assert current_measurement.true_peak_max >= prev_measurement.true_peak_max
-                assert np.all(current_measurement.true_peak_array >= prev_measurement.true_peak_array)
-                assert np.all(current_measurement.true_peak_array[silent_channels_ix] == -np.inf)
+                assert np.all(current_measurement.true_peak_current >= prev_measurement.true_peak_current)
+                assert np.all(current_measurement.true_peak_current[silent_channels_ix] == -np.inf)
 
             prev_measurement = current_measurement
             gate_block_index += 1


### PR DESCRIPTION
### TL;DR

Renames `true_peak_array` to `true_peak_current` in `CurrentMeasurement`, publishes the package to PyPI, and improves documentation clarity.

### What changed?

- The `true_peak_array` field on `CurrentMeasurement` has been renamed to `true_peak_current` to better reflect that it holds the current per-channel true peak values rather than a historical array.
- The package is now available on PyPI via `pip install lupy`. The installation instructions in the docs have been updated accordingly, and a PyPI project URL has been added.
- The SciPy intersphinx mapping now points to the version-agnostic URL instead of a pinned version.
- Documentation for `Meter` attributes has been expanded with descriptions for each scalar and array value, including guidance on using `CurrentMeasurement` and structured arrays (`block_data`, `true_peak_array`) for accessing historical measurements.
- A typo ("import" → "important") in the usage docs was corrected.

### How to test?

- Install the package with `pip install lupy` and verify it installs successfully.
- Run the existing test suite to confirm the `true_peak_current` rename is reflected correctly:
  - `test_true_peak_disabled` in `test_meter_options.py`
  - `test_meter_current_measurement` in `test_processing.py`

### Why make this change?

The previous name `true_peak_array` was ambiguous and could be confused with the historical true peak array (`Meter.true_peak_array`). Renaming it to `true_peak_current` makes the distinction clear. Publishing to PyPI makes the package more accessible, and the documentation improvements help users understand how to access the various measurement values exposed by the `Meter`.