### PR TITLE
Avoid array comparison if relative threshold hasn't changed

### DIFF
--- a/src/lupy/processing.py
+++ b/src/lupy/processing.py
@@ -216,6 +216,8 @@ class BlockProcessor(BaseProcessor[NumChannelsT]):
         )
         self._block_weighted_sums = np.zeros(self.MAX_BLOCKS, dtype=np.float64)
         self._quarter_block_weighted_sums = np.zeros(self.MAX_BLOCKS, dtype=np.float64)
+        self._blocks_above_abs_thresh = np.zeros(self.MAX_BLOCKS, dtype=bool)
+        self._blocks_above_rel_thresh = np.zeros(self.MAX_BLOCKS, dtype=bool)
 
         self._block_loudness = np.zeros(self.MAX_BLOCKS, dtype=np.float64)
         self._t = self._block_data['t']
@@ -306,6 +308,8 @@ class BlockProcessor(BaseProcessor[NumChannelsT]):
         self._quarter_block_weighted_sums[:] = 0
         self._block_loudness[:] = 0
         self._rel_threshold = SILENCE_DB
+        self._blocks_above_abs_thresh[:] = False
+        self._blocks_above_rel_thresh[:] = False
         self._above_rel_running_sum.clear()
         self._above_abs_running_sum.clear()
         self.integrated_lkfs = SILENCE_DB
@@ -321,27 +325,43 @@ class BlockProcessor(BaseProcessor[NumChannelsT]):
 
     def _calc_gating(self) -> None:
         block_lk = self._block_loudness[:self.block_index+1]
+        blocks_above_rel_thresh = self._blocks_above_rel_thresh[:self.block_index+1]
+        blocks_above_abs_thresh = self._blocks_above_abs_thresh[:self.block_index+1]
         block_wsums = self._block_weighted_sums[:self.block_index+1]
         cur_block_lk = block_lk[-1]
         cur_block_wsum = block_wsums[-1]
         above_abs = cur_block_lk >= -70
+        rel_threshold_changed = False
 
         if above_abs:
             self._above_abs_running_sum += cur_block_wsum
+        blocks_above_abs_thresh[-1] = above_abs
 
         if self._above_abs_running_sum == 0:
             rel_threshold = SILENCE_DB
         else:
             rel_threshold = lk_log10(self._above_abs_running_sum.mean) - 10
-        self._rel_threshold = rel_threshold
+            if rel_threshold != self._rel_threshold:
+                rel_threshold_changed = True
 
         rs = self._above_rel_running_sum
-        x = block_wsums[np.logical_and(
-            np.greater_equal(block_lk, rel_threshold),
-            np.greater_equal(block_lk, -70)
-        )]
-        rs.value = x.sum()
-        rs.count = x.size
+        if rel_threshold_changed:
+            blocks_above_rel_thresh[:] = block_lk >= rel_threshold
+            x = block_wsums[np.logical_and(
+                blocks_above_rel_thresh,
+                blocks_above_abs_thresh
+            )]
+            rs.value = x.sum()
+            rs.count = x.size
+        else:
+            # If the relative threshold hasn't changed, we can avoid doing
+            # a full array comparison and just add the current block to the running sum.
+            blocks_above_rel_thresh[-1] = cur_block_lk >= rel_threshold
+            if cur_block_lk >= rel_threshold and above_abs:
+                rs.value += cur_block_wsum
+                rs.count += 1
+
+        self._rel_threshold = rel_threshold
         if not rs.count:
             self.integrated_lkfs = SILENCE_DB
         else:

--- a/src/lupy/processing.py
+++ b/src/lupy/processing.py
@@ -216,8 +216,10 @@ class BlockProcessor(BaseProcessor[NumChannelsT]):
         )
         self._block_weighted_sums = np.zeros(self.MAX_BLOCKS, dtype=np.float64)
         self._quarter_block_weighted_sums = np.zeros(self.MAX_BLOCKS, dtype=np.float64)
-        self._blocks_above_abs_thresh = np.zeros(self.MAX_BLOCKS, dtype=bool)
-        self._blocks_above_rel_thresh = np.zeros(self.MAX_BLOCKS, dtype=bool)
+        self._block_weighted_sums = np.zeros(self.MAX_BLOCKS, dtype=np.float64)
+        self._quarter_block_weighted_sums = np.zeros(self.MAX_BLOCKS, dtype=np.float64)
+
+        self._block_loudness = np.zeros(self.MAX_BLOCKS, dtype=np.float64)
 
         self._block_loudness = np.zeros(self.MAX_BLOCKS, dtype=np.float64)
         self._t = self._block_data['t']
@@ -358,8 +360,7 @@ class BlockProcessor(BaseProcessor[NumChannelsT]):
             # a full array comparison and just add the current block to the running sum.
             blocks_above_rel_thresh[-1] = cur_block_lk >= rel_threshold
             if cur_block_lk >= rel_threshold and above_abs:
-                rs.value += cur_block_wsum
-                rs.count += 1
+                rs += cur_block_wsum
 
         self._rel_threshold = rel_threshold
         if not rs.count:


### PR DESCRIPTION
### TL;DR

Optimized the gating calculation to avoid redundant full-array comparisons when the relative threshold hasn't changed.

### What changed?

The `_calc_gating` method now tracks whether the relative threshold has changed between calls. When it hasn't changed, the method skips the full array comparison and instead incrementally updates the running sum with only the current block. Two new boolean arrays, `_blocks_above_abs_thresh` and `_blocks_above_rel_thresh`, are introduced to track per-block threshold state, and these are properly reset in the `reset()` method.

### How to test?

Run the existing test suite to verify integrated loudness calculations remain accurate. Additionally, compare loudness measurements before and after the change on known audio inputs to confirm the optimization produces identical results to the previous full-array approach.

### Why make this change?

The previous implementation recalculated the relative threshold sum across all blocks on every call, which was computationally wasteful. Since the relative threshold only changes when new blocks cross the absolute threshold, most calls can skip the expensive full-array scan and simply append the current block's contribution to the running sum, improving performance for long audio streams.