### PR TITLE
Typing adjustments

### DIFF
--- a/src/lupy/types.py
+++ b/src/lupy/types.py
@@ -18,12 +18,17 @@ __all__ = (
     'AnyArray', 'BoolArray', 'IndexArray', 'FloatArray', 'ComplexArray',
     'Float1dArray', 'Float2dArray', 'Float3dArray', 'Float2dArray32', 'AnyFloatArray',
     'AnyNdArray', 'Any1dArray', 'Any2dArray', 'Any3dArray', 'ShapeT',
-    'NumChannels', 'NumChannelsT', 'CurrentMeasurement',
+    'NumChannels', 'NumChannelsT', 'ChannelIndex', 'ChannelIndexT',
+    'CurrentMeasurement',
 )
 
 NumChannels = Literal[1, 2, 3, 5]
 """"""
 NumChannelsT = TypeVar('NumChannelsT', bound=NumChannels)
+""""""
+ChannelIndex = Literal[0, 1, 2, 3, 4]
+""""""
+ChannelIndexT = TypeVar('ChannelIndexT', bound=ChannelIndex)
 """"""
 
 Floating = np.floating

--- a/src/lupy/types.py
+++ b/src/lupy/types.py
@@ -36,16 +36,13 @@ DType_t = TypeVar("DType_t", bound=np.dtype[Any])
 DType_co = TypeVar("DType_co", bound=np.dtype[Any], covariant=True)
 """"""
 
-_1D: TypeAlias = tuple[int]
-_2D: TypeAlias = tuple[int, int]
-_3D: TypeAlias = tuple[int, int, int]
 
 ShapeT = TypeVar('ShapeT', bound=tuple[int,...])
 ShapeT_co = TypeVar('ShapeT_co', bound=tuple[int,...], covariant=True)
 
-_1DArray = np.ndarray[_1D, DType_co]
-_2DArray = np.ndarray[_2D, DType_co]
-_3DArray = np.ndarray[_3D, DType_co]
+_1DArray = np.ndarray[tuple[int], DType_co]
+_2DArray = np.ndarray[tuple[int, int], DType_co]
+_3DArray = np.ndarray[tuple[int, int, int], DType_co]
 
 
 # type AnyNdArray[_St: (tuple[int,...]), _Dt: (_AnyDtype)] = np.ndarray[_St, _Dt]

--- a/src/lupy/types.py
+++ b/src/lupy/types.py
@@ -31,7 +31,6 @@ Complex = np.complex128
 
 
 
-_AnyDtype: TypeAlias = np.dtype[Any]
 DType_t = TypeVar("DType_t", bound=np.dtype[Any])
 DType_co = TypeVar("DType_co", bound=np.dtype[Any], covariant=True)
 """"""

--- a/src/lupy/types.py
+++ b/src/lupy/types.py
@@ -40,7 +40,7 @@ _1D: TypeAlias = tuple[int]
 _2D: TypeAlias = tuple[int, int]
 _3D: TypeAlias = tuple[int, int, int]
 
-ShapeT = TypeVar('ShapeT', _1D, _2D, _3D)
+ShapeT = TypeVar('ShapeT', bound=tuple[int,...])
 ShapeT_co = TypeVar('ShapeT_co', bound=tuple[int,...], covariant=True)
 
 _1DArray = np.ndarray[_1D, DType_co]

--- a/src/lupy/typeutils.py
+++ b/src/lupy/typeutils.py
@@ -87,6 +87,24 @@ def ensure_nd_array(arr: AnyNdArray[Any, DType_co], ndim: int) -> AnyNdArray[Any
     return arr
 
 
+def is_array_of_shape(
+    arr: np.ndarray[tuple[int,...], DType_t],
+    shape: ShapeT
+) -> TypeIs[np.ndarray[ShapeT, DType_t]]:
+    """Check if the given array's shape matches the specified shape
+    """
+    return arr.shape == shape
+
+
+def ensure_array_of_shape(
+    arr: np.ndarray[tuple[int,...], DType_t],
+    shape: ShapeT
+) -> np.ndarray[ShapeT, DType_t]:
+    """Ensure the given array's shape matches the specified shape and return it
+    """
+    assert is_array_of_shape(arr, shape)
+    return arr
+
 
 def is_array_of_dtype(
     arr: AnyNdArray[ShapeT, Any],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from fractions import Fraction
 import numpy as np
 import pytest
 
-from lupy.types import FloatArray
+from lupy.types import *
 from compliance_cases import (
     ComplianceBase, cases_by_name, all_cases, true_peak_cases,
     bs_2217_compliance_cases,
@@ -54,7 +54,7 @@ def block_size(request) -> int:
     return request.param
 
 @pytest.fixture(params=[1, 2, 3, 5])
-def num_channels(request) -> int:
+def num_channels(request) -> NumChannels:
     return request.param
 
 @pytest.fixture(params=[
@@ -79,7 +79,7 @@ def true_peak_gate_duration(request) -> Fraction:
     (3, 0), (3, 1), (3, 2),
     (5, 0), (5, 1), (5, 2),
 ])
-def front_channels(request) -> tuple[int, int]:
+def front_channels(request) -> tuple[NumChannels, ChannelIndex]:
     return request.param
 
 @pytest.fixture(params=[
@@ -88,7 +88,7 @@ def front_channels(request) -> tuple[int, int]:
     (3, 0), (3, 1), (3, 2),
     (5, 0), (5, 1), (5, 2), (5, 3), (5, 4),
 ])
-def all_channels(request) -> tuple[int, int]:
+def all_channels(request) -> tuple[NumChannels, ChannelIndex]:
     return request.param
 
 @pytest.fixture(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from fractions import Fraction
 import numpy as np
 import pytest
 
-from lupy.types import *
+from lupy.types import FloatArray, ShapeT, NumChannels, ChannelIndex
 from compliance_cases import (
     ComplianceBase, cases_by_name, all_cases, true_peak_cases,
     bs_2217_compliance_cases,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, overload
 import os
 from fractions import Fraction
 import numpy as np
@@ -44,7 +44,15 @@ def lkfs_1k_sine() -> Callable[[int, int, float|FloatArray], FloatArray]:
     #     return amp * np.sin(2 * np.pi * fc * t)
     return gen_1k_sine
 
-def gen_1k_sine(count: int, sample_rate: int, amp: float|FloatArray = 1):
+@overload
+def gen_1k_sine(count: int, sample_rate: int, amp: float) -> FloatArray[tuple[int]]: ...
+@overload
+def gen_1k_sine(count: int, sample_rate: int, amp: FloatArray[ShapeT]) -> FloatArray[ShapeT]: ...
+def gen_1k_sine(
+    count: int,
+    sample_rate: int,
+    amp: float|FloatArray[ShapeT] = 1
+) -> FloatArray[ShapeT] | FloatArray[tuple[int]]:
     fc = 997
     t = np.arange(count) / sample_rate
     return amp * np.sin(2 * np.pi * fc * t)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, overload
+from typing import overload
 import os
 from fractions import Fraction
 import numpy as np
@@ -36,13 +36,6 @@ def inc_samples():
         return a
     return gen
 
-@pytest.fixture
-def lkfs_1k_sine() -> Callable[[int, int, float|FloatArray], FloatArray]:
-    # def gen(count: int, sample_rate: int, amp: float = 1):
-    #     fc = 997
-    #     t = np.arange(count) / sample_rate
-    #     return amp * np.sin(2 * np.pi * fc * t)
-    return gen_1k_sine
 
 @overload
 def gen_1k_sine(count: int, sample_rate: int, amp: float) -> FloatArray[tuple[int]]: ...

--- a/tests/test_meter_options.py
+++ b/tests/test_meter_options.py
@@ -5,7 +5,7 @@ import pytest
 import numpy as np
 
 from lupy import Meter
-from lupy.types import *
+from lupy.types import NumChannelsT
 from lupy.typeutils import is_array_of_shape
 
 from conftest import gen_1k_sine

--- a/tests/test_meter_options.py
+++ b/tests/test_meter_options.py
@@ -5,7 +5,8 @@ import pytest
 import numpy as np
 
 from lupy import Meter
-from lupy.types import Float2dArray, NumChannels
+from lupy.types import *
+from lupy.typeutils import is_array_of_shape
 
 from conftest import gen_1k_sine
 
@@ -14,11 +15,12 @@ from conftest import gen_1k_sine
 def build_samples(
     num_samples: int,
     sample_rate: int,
-    num_channels: NumChannels = 2,
+    num_channels: NumChannelsT = 2,
     sine_channels: Iterable[int]|None = (0, 1),
     sine_amp: float = 10 ** (-18/20),
-) -> Float2dArray:
+) -> np.ndarray[tuple[NumChannelsT, int], np.dtype[np.float64]]:
     samples = np.zeros((num_channels, num_samples), dtype=np.float64)
+    assert is_array_of_shape(samples, (num_channels, num_samples))
     if sine_channels is not None:
         sig = gen_1k_sine(num_samples, sample_rate, sine_amp)
         samples[np.array(sine_channels),...] = sig

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -6,7 +6,8 @@ import numpy as np
 
 from lupy import Meter, BlockProcessor
 from lupy.processing import SILENCE_DB
-from lupy.types import FloatArray, Float2dArray
+from lupy.types import *
+from lupy.typeutils import is_array_of_shape
 
 from conftest import gen_1k_sine
 from compliance_cases import BS2217_NPZ_DIR
@@ -20,12 +21,13 @@ def is_silent(request) -> bool:
 
 def build_samples(
     num_samples: int,
-    num_channels: int,
+    num_channels: NumChannelsT,
     sample_rate: int,
-    sine_channels: Iterable[int]|None,
-    sine_amp: float|FloatArray = 1,
-) -> Float2dArray:
+    sine_channels: Iterable[ChannelIndex]|None,
+    sine_amp: float|FloatArray[tuple[int]] = 1,
+) -> np.ndarray[tuple[NumChannelsT, int], np.dtype[np.float64]]:
     samples = np.zeros((num_channels, num_samples), dtype=np.float64)
+    assert is_array_of_shape(samples, (num_channels, num_samples))
     if sine_channels is not None:
         sig = gen_1k_sine(num_samples, sample_rate, sine_amp)
         samples[np.array(sine_channels),...] = sig
@@ -47,7 +49,7 @@ def test_integrated_lkfs(sample_rate, block_size, all_channels, is_silent):
     N, Fs = meter.sampler.total_samples, int(meter.sample_rate)
     num_blocks, gate_size = meter.sampler.num_blocks, meter.sampler.gate_size
 
-    src_data = build_samples(N, num_channels, Fs, [sine_channel], 1)
+    src_data = build_samples(N, num_channels, Fs, (sine_channel,), 1)
     assert src_data.shape == (num_channels, N)
 
     if is_silent:
@@ -87,7 +89,7 @@ def test_integrated_lkfs_neg18(sample_rate, block_size):
     N, Fs = meter.sampler.total_samples, int(meter.sample_rate)
     num_blocks, gate_size = meter.sampler.num_blocks, meter.sampler.gate_size
 
-    sine_channels = [0, 1]
+    sine_channels = (0, 1)
     amp = 10 ** (-18/20)
     src_data = build_samples(N, num_channels, Fs, sine_channels, amp)
     meter.write_all(src_data)

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from lupy import Meter, BlockProcessor
 from lupy.processing import SILENCE_DB
-from lupy.types import *
+from lupy.types import FloatArray, NumChannelsT, ChannelIndex, CurrentMeasurement
 from lupy.typeutils import is_array_of_shape
 
 from conftest import gen_1k_sine


### PR DESCRIPTION
### TL;DR

Added `ChannelIndex` and `ChannelIndexT` types, introduced shape-aware array utility functions, and improved type precision across the codebase.

### What changed?

- Added `ChannelIndex = Literal[0, 1, 2, 3, 4]` and `ChannelIndexT` TypeVar to `types.py` to represent valid channel indices with proper type constraints.
- Introduced `is_array_of_shape` and `ensure_array_of_shape` utility functions in `typeutils.py`, using `TypeIs` to narrow array types based on their shape at both runtime and type-check time.
- Replaced loose `int` annotations with `NumChannels`, `NumChannelsT`, and `ChannelIndex` in test fixtures and helper functions, making channel-related types more precise.
- Updated `build_samples` in test files to return shape-typed arrays (`np.ndarray[tuple[NumChannelsT, int], ...]`) and added `is_array_of_shape` assertions to enforce shape correctness.
- Improved `gen_1k_sine` with `@overload` signatures to correctly propagate return types depending on whether `amp` is a scalar `float` or a shaped `FloatArray`.
- Simplified `ShapeT` to use `bound=tuple[int, ...]` instead of a union of fixed-dimension tuple types, and inlined the `_1D`, `_2D`, `_3D` aliases directly into array type definitions.
- Removed the unused `lkfs_1k_sine` pytest fixture and the `_AnyDtype` alias.

### How to test?

Run the existing test suite. No new test cases are required, as the changes are primarily type-level improvements with runtime assertions added to `build_samples` calls to validate array shapes.

### Why make this change?

These changes improve static type safety by encoding channel index constraints and array shapes into the type system. This allows type checkers to catch mismatches between expected and actual array shapes or channel indices earlier, reducing the risk of subtle bugs in audio processing logic.