### PR TITLE
Improve efficiency and documentation for `TruePeakFilter` and `resample` module

### DIFF
--- a/src/lupy/filters.py
+++ b/src/lupy/filters.py
@@ -198,10 +198,14 @@ class BaseFilter(Generic[T, NumChannelsT], ABC):
 
 
 class TruePeakFilter(BaseFilter[Float1dArray, NumChannelsT]):
-    """4x Oversampling filter with interpolating FIR window
+    """Oversampling filter with interpolating FIR window
+
+    An :attr:`upsample_factor` of 4 is recommended for sample rates below 88.2 kHz,
+    while a factor of 2 has proven to be sufficient for sample rates of
+    88.2 kHz and above.
     """
     upsample_factor: int
-    """Upsampling factor (currently only 4 is supported)"""
+    """Upsampling factor"""
     def __init__(
         self,
         num_channels: NumChannelsT,

--- a/src/lupy/signalutils/resample.py
+++ b/src/lupy/signalutils/resample.py
@@ -49,13 +49,13 @@ def calc_tp_fir_win(upsample_factor: int) -> Float1dArray:
 
     max_rate = upsample_factor
     f_c = 1 / max_rate
-    half_len = 8 * max_rate
+    numtaps = 8 * max_rate + 1
 
     # Casting to str because firwin's type hints are not compatible with the
     # implementation.
     window = cast(str, ('kaiser', 5.0))
     h = firwin(
-        half_len + 1,       # len == 33 with upsample factor of 4
+        numtaps,       # len == 33 with upsample factor of 4
         f_c,
         window=window
     )

--- a/src/lupy/signalutils/resample.py
+++ b/src/lupy/signalutils/resample.py
@@ -38,13 +38,13 @@ def calc_tp_fir_win(upsample_factor: int) -> Float1dArray:
 
     max_rate = upsample_factor
     f_c = 1 / max_rate
-    half_len = 10 * max_rate
+    half_len = 8 * max_rate
 
     # Casting to str because firwin's type hints are not compatible with the
     # implementation.
     window = cast(str, ('kaiser', 5.0))
     h = firwin(
-        half_len + 1,       # len == 41 with upsample factor of 4
+        half_len + 1,       # len == 33 with upsample factor of 4
         f_c,
         window=window
     )

--- a/src/lupy/signalutils/resample.py
+++ b/src/lupy/signalutils/resample.py
@@ -35,7 +35,7 @@ class ResamplePolyParams(NamedTuple):
 def calc_tp_fir_win(upsample_factor: int) -> Float1dArray:
     """Calculate an appropriate low-pass FIR filter for over-sampling
 
-    The method matches what is done by in :func:`scipy.signal.resample_poly`,
+    The method matches what is done in :func:`scipy.signal.resample_poly`,
     but with the following adjustments:
 
     - The downsampling factor is fixed as 1 (no downsampling) since only

--- a/src/lupy/signalutils/resample.py
+++ b/src/lupy/signalutils/resample.py
@@ -36,11 +36,7 @@ def calc_tp_fir_win(upsample_factor: int) -> Float1dArray:
     The method matches that of :func:`scipy.signal.resample_poly`
     """
 
-    up, down = upsample_factor, 1
-    g_ = math.gcd(up, down)
-    up //= g_
-    down //= g_
-    max_rate = max(up, down)
+    max_rate = upsample_factor
     f_c = 1 / max_rate
     half_len = 10 * max_rate
 

--- a/src/lupy/signalutils/resample.py
+++ b/src/lupy/signalutils/resample.py
@@ -27,13 +27,24 @@ class ResamplePolyParams(NamedTuple):
     result_slice: tuple[slice, ...]
     """Slice object to extract the valid output samples from the
     polyphase upfirdn filtering step."""
+
+
 # Adapted from:
 # https://github.com/scipy/scipy/blob/87c46641a8b3b5b47b81de44c07b840468f7ebe7/scipy/signal/_signaltools.py#L3363-L3384
 #
 def calc_tp_fir_win(upsample_factor: int) -> Float1dArray:
     """Calculate an appropriate low-pass FIR filter for over-sampling
 
-    The method matches that of :func:`scipy.signal.resample_poly`
+    The method matches what is done by in :func:`scipy.signal.resample_poly`,
+    but with the following adjustments:
+
+    - The downsampling factor is fixed as 1 (no downsampling) since only
+      upsampling is required for :term:`True Peak` detection.
+    - The FIR filter length is ``8 * upsample_factor + 1`` instead of ``10 * upsample_factor + 1``.
+      This is a minimal length that still performs well for true peak detection,
+      but is much more efficient than the default length used by
+      :func:`scipy.signal.resample_poly`.
+
     """
 
     max_rate = upsample_factor


### PR DESCRIPTION
### TL;DR

Improved True Peak filter flexibility and efficiency by supporting variable upsampling factors and reducing the FIR filter length.

### What changed?

- `TruePeakFilter` now supports variable upsampling factors rather than being restricted to 4x only. An upsampling factor of 4 is recommended for sample rates below 88.2 kHz, while a factor of 2 is sufficient for 88.2 kHz and above.
- The FIR filter window length in `calc_tp_fir_win` was reduced from `10 * upsample_factor + 1` (41 taps at 4x) to `8 * upsample_factor + 1` (33 taps at 4x).
- Simplified the `calc_tp_fir_win` calculation by removing the unnecessary GCD reduction step, since the downsampling factor is always 1 for True Peak detection.

### How to test?

Run the existing test suite to verify True Peak detection accuracy is maintained. Additionally, test with audio at both standard sample rates (below 88.2 kHz) and high sample rates (88.2 kHz and above) using upsampling factors of 4 and 2 respectively, confirming that True Peak measurements remain within acceptable tolerances.

### Why make this change?

The previous implementation was unnecessarily constrained to a fixed 4x upsampling factor and used a longer FIR filter than required. The shorter filter length (`8 * upsample_factor + 1`) is sufficient for accurate True Peak detection while being more computationally efficient. Supporting a 2x upsampling factor for higher sample rates further reduces processing overhead when full 4x oversampling is not needed.