### PR TITLE
Move `Meter.reset` into benchmark teardown

### DIFF
--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -341,7 +341,7 @@ def test_meter_benchmark(sample_rate, random_samples, benchmark):
         bench,
         teardown=teardown,
         warmup_rounds=10,
-        rounds=rounds[sample_rate],
+        rounds=rounds.get(sample_rate, 200),
     )
 
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -326,7 +326,24 @@ def test_meter_benchmark(sample_rate, random_samples, benchmark):
     def bench():
         meter.write_all(src_data)
         meter.reset()
-    benchmark(bench)
+
+    def teardown():
+        meter.reset()
+
+    rounds = {
+        44100: 300,
+        48000: 300,
+        88200: 200,
+        96000: 200,
+    }
+
+    # Using pedantic so that `meter.reset()` isn't included in the measurements
+    benchmark.pedantic(
+        bench,
+        teardown=teardown,
+        warmup_rounds=10,
+        rounds=rounds[sample_rate],
+    )
 
 
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -325,7 +325,6 @@ def test_meter_benchmark(sample_rate, random_samples, benchmark):
 
     def bench():
         meter.write_all(src_data)
-        meter.reset()
 
     def teardown():
         meter.reset()


### PR DESCRIPTION
**Important**:
This will introduce false positives in all `test_meter_benchmark` results.  That's intentional as `Meter.reset()` isn't a performance-related method.  Its overhead will no longer be measured after this is merged.

## Summary by Sourcery

Tests:
- Adjust meter benchmark test to run via benchmark.pedantic with a teardown that performs meter.reset, and configure sample-rate-specific round counts and warmup rounds to refine measurements.

## Summary by Sourcery

Tests:
- Run meter benchmark via benchmark.pedantic with a teardown that calls meter.reset and configure sample-rate-specific rounds and warmup rounds to refine performance measurements.