### PR TITLE
Add exclusions for untestable lines in coverage reports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,9 @@ dev = [
 
 [tool.mypy]
 packages = "lupy"
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+]


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update coverage configuration to exclude `pragma: no cover` and `raise NotImplementedError` lines from coverage reports.