### PR TITLE
Use a fixed seed for rng in `random_samples` fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from compliance_cases import (
 IS_CI = 'CI' in os.environ
 
 nan = np.nan
-rng = np.random.default_rng()
+rng = np.random.default_rng(seed=42)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Configure the shared NumPy RNG in tests with a fixed seed to make random_samples-based tests deterministic.