### PR TITLE
Add ruff linting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,8 @@ jobs:
         run: uv sync --frozen --no-dev --group test
       - name: Run type checks
         run: uv run mypy
+      - name: Run lint checks
+        run: uv run ruff check
 
   test:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,17 @@ uv run mypy
 This should **always** pass without any errors or warnings. If you encounter any type errors, please fix them before committing your code.
 
 
+## Linting
+
+Linting is done using `ruff`. To run linting, use the following command:
+
+```bash
+uv run ruff check
+```
+
+This should **always** pass without any errors or warnings. If you encounter any linting errors, please fix them before committing your code.
+
+
 ## Typing Preferences
 
 - Use strict typing as much as possible.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ test = [
     "scipy-stubs; python_version>='3.10'",
     "pytest-test-groups>=1.2.1",
     "pytest-cov>=7.1.0",
+    "ruff>=0.15.12",
 ]
 doc = [
     "sphinx",
@@ -79,6 +80,11 @@ dev = [
 
 [tool.mypy]
 packages = "lupy"
+
+
+[tool.ruff]
+include = ["pyproject.toml", "src/**/*.py", "src/**/*.pyi", "tests/**/*.py"]
+
 
 [tool.coverage.report]
 exclude_lines = [

--- a/src/lupy/__init__.py
+++ b/src/lupy/__init__.py
@@ -1,3 +1,19 @@
-from .sampling import *
-from .processing import *
-from .meter import *
+from .sampling import (
+    Sampler,
+    TruePeakSampler,
+    ThreadSafeSampler,
+    ThreadSafeTruePeakSampler,
+)
+from .processing import BlockProcessor, TruePeakProcessor
+from .meter import Meter
+
+
+__all__ = [
+    "Sampler",
+    "TruePeakSampler",
+    "ThreadSafeSampler",
+    "ThreadSafeTruePeakSampler",
+    "BlockProcessor",
+    "TruePeakProcessor",
+    "Meter",
+]

--- a/src/lupy/arraytypes.pyi
+++ b/src/lupy/arraytypes.pyi
@@ -6,7 +6,7 @@ from typing import Generic, Literal, Any, Self, overload
 import numpy as np
 import numpy.typing as npt
 
-from lupy.types import Float1dArray, Float2dArray, NumChannelsT
+from lupy.types import Float1dArray, NumChannelsT
 
 
 __all__ = (

--- a/src/lupy/filters.py
+++ b/src/lupy/filters.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TypeVar, Generic, Literal, cast
+from typing import TypeVar, Generic, cast
 from abc import ABC, abstractmethod
 import sys
 if sys.version_info < (3, 11):
@@ -13,7 +13,9 @@ import numpy as np
 from scipy import signal
 
 
-from .types import *
+from .types import (
+    Float1dArray, Float2dArray, AnyArray, SosCoeff, SosZI, NumChannelsT,
+)
 from .signalutils.sosfilt import sosfilt, validate_sos
 from .signalutils.resample import ResamplePoly, calc_tp_fir_win
 from .typeutils import (

--- a/src/lupy/meter.py
+++ b/src/lupy/meter.py
@@ -7,7 +7,10 @@ import numpy as np
 from .sampling import Sampler, TruePeakSampler
 from .processing import BlockProcessor, TruePeakProcessor, SILENCE_DB
 from .arraytypes import MeterArray, TruePeakArray
-from .types import *
+from .types import (
+    NumChannelsT, Float1dArray, Float2dArray, Float2dArray32, Any2dArray,
+    CurrentMeasurement, Floating,
+)
 from .typeutils import is_2d_array, ensure_2d_array, is_float64_array
 
 __all__ = ('Meter',)

--- a/src/lupy/processing.py
+++ b/src/lupy/processing.py
@@ -12,7 +12,10 @@ import bisect
 import numpy as np
 
 from .arraytypes import MeterArray, TruePeakArray
-from .types import *
+from .types import (
+    NumChannelsT, Float1dArray, Float2dArray, Any1dArray,
+    Floating, FloatArray,
+)
 from .typeutils import ensure_nd_array, build_meter_array, build_true_peak_array
 from .filters import TruePeakFilter
 

--- a/src/lupy/sampling.py
+++ b/src/lupy/sampling.py
@@ -13,7 +13,10 @@ import threading
 
 import numpy as np
 
-from .types import *
+from .types import (
+    NumChannelsT, Float2dArray, Float3dArray, AnyArray, IndexArray,
+    FloatArray, Float2dArray32,
+)
 from .typeutils import ensure_2d_array, is_float64_array
 from .filters import FilterGroup, HS_COEFF, HP_COEFF
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -4,7 +4,7 @@ import numpy as np
 from scipy import signal
 import pytest
 
-from lupy.filters import HS_COEFF, HP_COEFF, Coeff, Filter, FilterGroup, TruePeakFilter
+from lupy.filters import HS_COEFF, HP_COEFF, Filter, FilterGroup, TruePeakFilter
 
 
 

--- a/tests/test_meter_options.py
+++ b/tests/test_meter_options.py
@@ -64,7 +64,7 @@ def test_short_term_disabled_and_lra_enabled_raises():
 
     # LRA requires short-term to be enabled which raises an error.
     with pytest.raises(ValueError) as excinfo:
-        meter = Meter(
+        _ = Meter(
             block_size=block_size,
             num_channels=num_channels,
             sample_rate=sample_rate,

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -48,7 +48,7 @@ def test_integrated_lkfs(sample_rate, block_size, all_channels, is_silent):
     )
 
     N, Fs = meter.sampler.total_samples, int(meter.sample_rate)
-    num_blocks, gate_size = meter.sampler.num_blocks, meter.sampler.gate_size
+    gate_size = meter.sampler.gate_size
 
     src_data = build_samples(N, num_channels, Fs, (sine_channel,), 1)
     assert src_data.shape == (num_channels, N)
@@ -89,7 +89,7 @@ def test_integrated_lkfs_neg18(sample_rate, block_size):
     )
 
     N, Fs = meter.sampler.total_samples, int(meter.sample_rate)
-    num_blocks, gate_size = meter.sampler.num_blocks, meter.sampler.gate_size
+    gate_size = meter.sampler.gate_size
 
     sine_channels = (0, 1)
     amp = 10 ** (-18/20)

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -217,9 +217,9 @@ def test_write(sample_rate, block_size, num_channels, random_samples, inc_sample
         T_g = .4
         overlap = .75
         step = 1 - overlap
-        l = int(T_g * (j * step    ) * sampler.sample_rate)
-        u = int(T_g * (j * step + 1) * sampler.sample_rate)
-        return l, u
+        start = int(T_g * (j * step    ) * sampler.sample_rate)
+        end = int(T_g * (j * step + 1) * sampler.sample_rate)
+        return start, end
 
     def read_block():
         nonlocal src_data_index

--- a/uv.lock
+++ b/uv.lock
@@ -690,6 +690,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-test-groups" },
     { name = "pytest-xdist" },
+    { name = "ruff" },
     { name = "scipy-stubs", version = "1.15.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy-stubs", version = "1.17.1.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -709,6 +710,7 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-test-groups" },
     { name = "pytest-xdist" },
+    { name = "ruff" },
     { name = "scipy-stubs", version = "1.15.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy-stubs", version = "1.17.1.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
@@ -730,6 +732,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-test-groups", specifier = ">=1.2.1" },
     { name = "pytest-xdist" },
+    { name = "ruff", specifier = ">=0.15.12" },
     { name = "scipy-stubs", marker = "python_full_version >= '3.10'" },
     { name = "sphinx" },
 ]
@@ -744,6 +747,7 @@ test = [
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-test-groups", specifier = ">=1.2.1" },
     { name = "pytest-xdist" },
+    { name = "ruff", specifier = ">=0.15.12" },
     { name = "scipy-stubs", marker = "python_full_version >= '3.10'" },
 ]
 
@@ -1379,6 +1383,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/f9/41dc953bbeb056c17d5f7a519f50fdf010bd0553be2d630bc69d1e022703/roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2", size = 9077, upload-time = "2025-12-17T18:25:34.381Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7", size = 7676, upload-time = "2025-12-17T18:25:33.098Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Introduce Ruff linting to the project and update code to satisfy lint rules while tightening public exports.

Enhancements:
- Restrict the package public API by explicitly importing and defining __all__ in the top-level package module.
- Clean up type imports and unused variables to comply with linting and improve code clarity.
- Rename internal variables in tests for clearer semantics and style compliance.

Build:
- Add Ruff as a development dependency and configure its target files in pyproject.toml.

Documentation:
- Document Ruff-based linting and its usage in the contributor guidelines.

Tests:
- Adjust tests to reflect minor API and style changes without altering behavior.