### PR TITLE
Include test modules in type checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ dev = [
 ]
 
 [tool.mypy]
-packages = "lupy"
+files = ["src/lupy/", "tests/**/*.py"]
 
 
 [tool.ruff]

--- a/tests/compliance_cases.py
+++ b/tests/compliance_cases.py
@@ -22,6 +22,7 @@ BS2217_METAFILE = BS2217_ROOT / 'meta.json'
 nan = np.nan
 
 BitDepth = Literal[16, 24, 32]
+_BitDepthOpts: tuple[BitDepth, ...] = (16, 24, 32)
 _NumChannelsOpts: tuple[NumChannels, ...] = (1, 2, 3, 5)
 NumChannelsWithLFE = Union[NumChannels, Literal[6]]
 _NumChannelsWithLFEOpts: tuple[NumChannelsWithLFE, ...] = (1, 2, 3, 5, 6)
@@ -43,8 +44,8 @@ def load_bs2217_metadata() -> dict[str, BS2217FileMeta]:
         data = json.load(f)
     result: dict[str, BS2217FileMeta] = {}
     for item in data.values():
-        bit_depth: int|BitDepth = int(item['bit_depth'])
-        assert bit_depth in (16, 24, 32)
+        bit_depth = int(item['bit_depth'])
+        assert bit_depth in _BitDepthOpts
         num_channels = int(item['num_channels'])
         assert num_channels in _NumChannelsWithLFEOpts
         meta = BS2217FileMeta(

--- a/tests/compliance_cases.py
+++ b/tests/compliance_cases.py
@@ -21,6 +21,7 @@ BS2217_METAFILE = BS2217_ROOT / 'meta.json'
 
 nan = np.nan
 
+BitDepth = Literal[16, 24, 32]
 _NumChannelsOpts: tuple[NumChannels, ...] = (1, 2, 3, 5)
 NumChannelsWithLFE = Union[NumChannels, Literal[6]]
 _NumChannelsWithLFEOpts: tuple[NumChannelsWithLFE, ...] = (1, 2, 3, 5, 6)
@@ -32,7 +33,7 @@ class BS2217FileMeta(NamedTuple):
     name: str
     num_channels: NumChannelsWithLFE
     sample_rate: int
-    bit_depth: Literal[16, 24, 32]
+    bit_depth: BitDepth
     is_float: bool
     lkfs_expected: float
 
@@ -42,7 +43,7 @@ def load_bs2217_metadata() -> dict[str, BS2217FileMeta]:
         data = json.load(f)
     result: dict[str, BS2217FileMeta] = {}
     for item in data.values():
-        bit_depth = int(item['bit_depth'])
+        bit_depth: int|BitDepth = int(item['bit_depth'])
         assert bit_depth in (16, 24, 32)
         num_channels = int(item['num_channels'])
         assert num_channels in _NumChannelsWithLFEOpts

--- a/tests/data/bs2217/unpack.py
+++ b/tests/data/bs2217/unpack.py
@@ -172,7 +172,7 @@ def convert_wav_to_npz(wav_file: Path, npz_dir: Path, base_meta: FileMeta) -> tu
     )
     return npz_file, meta_full
 
-def convert_all_wav_to_npz():
+def convert_all_wav_to_npz() -> None:
     NPZ_DIR.mkdir(exist_ok=True)
     metadata = load_metadata(META_FILE)
     all_meta_full: dict[str, FileMetaFull] = {}

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -14,7 +14,7 @@ def bench_sample_rate(request) -> int:
 
 
 @pytest.mark.parametrize('coeff', [HS_COEFF, HP_COEFF])
-def test_filter_requantize(coeff, sample_rate):
+def test_filter_requantize(coeff, sample_rate) -> None:
     orig_sample_rate = coeff.sample_rate
     quantized = coeff.as_sample_rate(sample_rate)
 
@@ -68,7 +68,7 @@ def test_filter_group_single_channel_1d_input() -> None:
 
 
 @pytest.mark.benchmark(group='filter')
-def test_filter_benchmark(benchmark, random_samples, num_channels, bench_sample_rate):
+def test_filter_benchmark(benchmark, random_samples, num_channels, bench_sample_rate) -> None:
     sample_rate = bench_sample_rate
     block_size = sample_rate // 100
     assert sample_rate % block_size == 0
@@ -88,7 +88,7 @@ def test_filter_benchmark(benchmark, random_samples, num_channels, bench_sample_
     benchmark(bench)
 
 @pytest.mark.benchmark(group='truepeak_filter')
-def test_truepeak_filter_benchmark(benchmark, random_samples, num_channels, bench_sample_rate):
+def test_truepeak_filter_benchmark(benchmark, random_samples, num_channels, bench_sample_rate) -> None:
     sample_rate = bench_sample_rate
     up_sample = 4 if sample_rate < 88200 else 2
     block_size = sample_rate // 100

--- a/tests/test_meter_options.py
+++ b/tests/test_meter_options.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
-from typing import Iterable
+from typing import Iterable, Literal
 
 import pytest
 import numpy as np
 
 from lupy import Meter
-from lupy.types import NumChannelsT
+from lupy.types import NumChannelsT, NumChannels
 from lupy.typeutils import is_array_of_shape
 
 from conftest import gen_1k_sine
@@ -15,10 +15,10 @@ from conftest import gen_1k_sine
 def build_samples(
     num_samples: int,
     sample_rate: int,
-    num_channels: NumChannelsT = 2,
+    num_channels: NumChannelsT|Literal[2] = 2,
     sine_channels: Iterable[int]|None = (0, 1),
     sine_amp: float = 10 ** (-18/20),
-) -> np.ndarray[tuple[NumChannelsT, int], np.dtype[np.float64]]:
+) -> np.ndarray[tuple[NumChannelsT|Literal[2], int], np.dtype[np.float64]]:
     samples = np.zeros((num_channels, num_samples), dtype=np.float64)
     assert is_array_of_shape(samples, (num_channels, num_samples))
     if sine_channels is not None:
@@ -31,7 +31,7 @@ def build_samples(
 def test_momentary_disabled() -> None:
     sample_rate = 48000
     block_size = 128
-    num_channels = 2
+    num_channels: NumChannels = 2
     meter = Meter(
         block_size=block_size,
         num_channels=num_channels,
@@ -60,7 +60,7 @@ def test_momentary_disabled() -> None:
 def test_short_term_disabled_and_lra_enabled_raises() -> None:
     sample_rate = 48000
     block_size = 128
-    num_channels = 2
+    num_channels: NumChannels = 2
 
     # LRA requires short-term to be enabled which raises an error.
     with pytest.raises(ValueError) as excinfo:
@@ -77,7 +77,7 @@ def test_short_term_disabled_and_lra_enabled_raises() -> None:
 def test_short_term_disabled() -> None:
     sample_rate = 48000
     block_size = 128
-    num_channels = 2
+    num_channels: NumChannels = 2
 
     meter = Meter(
         block_size=block_size,
@@ -108,7 +108,7 @@ def test_short_term_disabled() -> None:
 def test_lra_disabled() -> None:
     sample_rate = 48000
     block_size = 128
-    num_channels = 2
+    num_channels: NumChannels = 2
     meter = Meter(
         block_size=block_size,
         num_channels=num_channels,
@@ -137,7 +137,7 @@ def test_lra_disabled() -> None:
 def test_true_peak_disabled() -> None:
     sample_rate = 48000
     block_size = 128
-    num_channels = 2
+    num_channels: NumChannels = 2
     meter = Meter(
         block_size=block_size,
         num_channels=num_channels,
@@ -164,10 +164,10 @@ def test_true_peak_disabled() -> None:
 
 def make_meter(
     block_size: int = 128,
-    num_channels: NumChannelsT = 2,
+    num_channels: NumChannelsT|Literal[2] = 2,
     sample_rate: int = 48000,
     true_peak_enabled: bool = True,
-) -> Meter[NumChannelsT]:
+) -> Meter[NumChannelsT|Literal[2]]:
     return Meter(
         block_size=block_size,
         num_channels=num_channels,

--- a/tests/test_meter_options.py
+++ b/tests/test_meter_options.py
@@ -28,7 +28,7 @@ def build_samples(
 
 
 
-def test_momentary_disabled():
+def test_momentary_disabled() -> None:
     sample_rate = 48000
     block_size = 128
     num_channels = 2
@@ -57,7 +57,7 @@ def test_momentary_disabled():
     assert current_measurement.momentary == 0.0
 
 
-def test_short_term_disabled_and_lra_enabled_raises():
+def test_short_term_disabled_and_lra_enabled_raises() -> None:
     sample_rate = 48000
     block_size = 128
     num_channels = 2
@@ -74,7 +74,7 @@ def test_short_term_disabled_and_lra_enabled_raises():
     assert 'lra' in str(excinfo.value).lower() and 'short-term' in str(excinfo.value).lower()
 
 
-def test_short_term_disabled():
+def test_short_term_disabled() -> None:
     sample_rate = 48000
     block_size = 128
     num_channels = 2
@@ -105,7 +105,7 @@ def test_short_term_disabled():
     assert current_measurement.short_term == 0.0
 
 
-def test_lra_disabled():
+def test_lra_disabled() -> None:
     sample_rate = 48000
     block_size = 128
     num_channels = 2
@@ -134,7 +134,7 @@ def test_lra_disabled():
     assert current_measurement.lra == 0.0
 
 
-def test_true_peak_disabled():
+def test_true_peak_disabled() -> None:
     sample_rate = 48000
     block_size = 128
     num_channels = 2
@@ -176,7 +176,7 @@ def make_meter(
     )
 
 
-def test_set_paused_blocks_writes():
+def test_set_paused_blocks_writes() -> None:
     """Writes are discarded while paused; can_write and can_process return False."""
     meter = make_meter()
     meter.set_paused(True)
@@ -190,7 +190,7 @@ def test_set_paused_blocks_writes():
     assert meter.sampler.samples_available == 0
 
 
-def test_set_paused_clears_buffer():
+def test_set_paused_clears_buffer() -> None:
     """Buffered samples are cleared when the meter is paused."""
     meter = make_meter()
     # Write enough blocks to have some buffered data
@@ -202,7 +202,7 @@ def test_set_paused_clears_buffer():
     assert meter.sampler.samples_available == 0
 
 
-def test_set_paused_noop_if_same_state():
+def test_set_paused_noop_if_same_state() -> None:
     """set_paused is idempotent: calling with the current state does nothing."""
     meter = make_meter()
     block = build_samples(meter.block_size, meter.sample_rate)
@@ -213,7 +213,7 @@ def test_set_paused_noop_if_same_state():
     assert meter.sampler.samples_available == samples_before
 
 
-def test_set_paused_resume():
+def test_set_paused_resume() -> None:
     """Unpausing allows writes to proceed again."""
     meter = make_meter()
     meter.set_paused(True)
@@ -222,7 +222,7 @@ def test_set_paused_resume():
     assert meter.can_write()
 
 
-def test_reset_with_true_peak_enabled():
+def test_reset_with_true_peak_enabled() -> None:
     """reset() reinitialises the true-peak processor when true_peak_enabled."""
     meter = make_meter(true_peak_enabled=True)
     N = meter.sampler.total_samples
@@ -236,7 +236,7 @@ def test_reset_with_true_peak_enabled():
     assert meter.true_peak_processor.tp_array.size == 0
 
 
-def test_process_single_block():
+def test_process_single_block() -> None:
     """process(process_all=False) processes exactly one gating block."""
     meter = make_meter()
 
@@ -254,7 +254,7 @@ def test_process_single_block():
 
 
 
-def test_current_measurement_empty():
+def test_current_measurement_empty() -> None:
     """current_measurement returns silence defaults before any block is processed."""
     from lupy.processing import SILENCE_DB
     meter = make_meter()
@@ -265,7 +265,7 @@ def test_current_measurement_empty():
     assert m.time == 0
 
 
-def test_write_all_truncates_non_multiple():
+def test_write_all_truncates_non_multiple() -> None:
     """write_all discards trailing samples that don't fill a complete block.
 
     With an input length of ``3 * block_size + extra`` (well below gate_size),

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from lupy import Meter, BlockProcessor
 from lupy.processing import SILENCE_DB, RunningSum, lk_log10, from_lk_log10, TruePeakProcessor
-from lupy.types import FloatArray, NumChannelsT, ChannelIndex, CurrentMeasurement
+from lupy.types import FloatArray, NumChannels, NumChannelsT, ChannelIndex, CurrentMeasurement
 from lupy.typeutils import is_array_of_shape
 
 from conftest import gen_1k_sine
@@ -77,7 +77,7 @@ def test_integrated_lkfs(sample_rate, block_size, all_channels, is_silent) -> No
 # Stereo 1k (997 Hz) sine at -18 dBFS should read -18 LUFS
 @pytest.mark.slow
 def test_integrated_lkfs_neg18(sample_rate, block_size) -> None:
-    num_channels = 2
+    num_channels: NumChannels = 2
     meter = Meter(
         block_size=block_size,
         num_channels=num_channels,
@@ -91,7 +91,7 @@ def test_integrated_lkfs_neg18(sample_rate, block_size) -> None:
     N, Fs = meter.sampler.total_samples, int(meter.sample_rate)
     gate_size = meter.sampler.gate_size
 
-    sine_channels = (0, 1)
+    sine_channels: tuple[ChannelIndex, ...] = (0, 1)
     amp = 10 ** (-18/20)
     src_data = build_samples(N, num_channels, Fs, sine_channels, amp)
     meter.write_all(src_data)
@@ -319,7 +319,7 @@ def test_true_peak_gate_blocks(
 @pytest.mark.benchmark(group='meter')
 def test_meter_benchmark(sample_rate, random_samples, benchmark) -> None:
     block_size = 1024
-    num_channels = 2
+    num_channels: NumChannels = 2
     meter = Meter(block_size=block_size, num_channels=num_channels, sample_rate=sample_rate)
 
     N = sample_rate * 1
@@ -521,7 +521,7 @@ def test_true_peak_processor_benchmark(benchmark, tp_sample_rate: int) -> None:
     Provides a measurement baseline for the polyphase FIR upsampling path so that
     any future optimisation of TruePeakFilter / _UpFIRDn can be tracked here.
     """
-    num_channels = 2
+    num_channels: NumChannels = 2
     gate_size = 1024
     proc = TruePeakProcessor(num_channels=num_channels, gate_size=gate_size, sample_rate=tp_sample_rate)
     rng = np.random.default_rng(42)

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -35,7 +35,7 @@ def build_samples(
 
 
 @pytest.mark.slow
-def test_integrated_lkfs(sample_rate, block_size, all_channels, is_silent):
+def test_integrated_lkfs(sample_rate, block_size, all_channels, is_silent) -> None:
     num_channels, sine_channel = all_channels
     meter = Meter(
         block_size=block_size,
@@ -76,7 +76,7 @@ def test_integrated_lkfs(sample_rate, block_size, all_channels, is_silent):
 # https://tech.ebu.ch/docs/tech/tech3341.pdf Section 2.9
 # Stereo 1k (997 Hz) sine at -18 dBFS should read -18 LUFS
 @pytest.mark.slow
-def test_integrated_lkfs_neg18(sample_rate, block_size):
+def test_integrated_lkfs_neg18(sample_rate, block_size) -> None:
     num_channels = 2
     meter = Meter(
         block_size=block_size,
@@ -102,7 +102,7 @@ def test_integrated_lkfs_neg18(sample_rate, block_size):
 
 
 @pytest.mark.slow
-def test_compliance_cases(sample_rate, compliance_case):
+def test_compliance_cases(sample_rate, compliance_case) -> None:
     block_size = 128
     num_channels = compliance_case.num_channels
     meter = Meter(block_size=block_size, num_channels=num_channels, sample_rate=sample_rate)
@@ -156,7 +156,7 @@ def test_compliance_cases(sample_rate, compliance_case):
 
 
 @pytest.mark.slow
-def test_bs2217_compliance_cases(bs_2217_compliance_case):
+def test_bs2217_compliance_cases(bs_2217_compliance_case) -> None:
     # This is separate from the other compliance cases since we're only
     # testing at 48k and only checking integrated LKFS
     sample_rate = 48000
@@ -199,7 +199,7 @@ def test_bs2217_compliance_cases(bs_2217_compliance_case):
     assert lufs - tol <= integrated <= lufs + tol
 
 
-def test_meter_current_measurement(all_channels):
+def test_meter_current_measurement(all_channels) -> None:
     num_channels, sine_channel = all_channels
     silent_channels_ix = np.array(
         [i for i in range(num_channels) if i != sine_channel],
@@ -273,7 +273,7 @@ def test_true_peak_gate_blocks(
     true_peak_gate_duration,
     sample_rate,
     true_peak_compliance_case
-):
+) -> None:
     block_size = 128
     num_channels = true_peak_compliance_case.num_channels
     meter = Meter(
@@ -317,7 +317,7 @@ def test_true_peak_gate_blocks(
 
 
 @pytest.mark.benchmark(group='meter')
-def test_meter_benchmark(sample_rate, random_samples, benchmark):
+def test_meter_benchmark(sample_rate, random_samples, benchmark) -> None:
     block_size = 1024
     num_channels = 2
     meter = Meter(block_size=block_size, num_channels=num_channels, sample_rate=sample_rate)
@@ -401,7 +401,7 @@ def processor_bench_data(request) -> tuple[np.ndarray, int, BlockProcessor, Proc
 
 
 @pytest.mark.benchmark(group='block_processor')
-def test_block_processor_benchmark(benchmark, processor_bench_data):
+def test_block_processor_benchmark(benchmark, processor_bench_data) -> None:
     samples, num_gate_blocks, processor, mode = processor_bench_data
 
     def bench():

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -320,7 +320,7 @@ def test_thread_safe_sampler_lock_context():
         pass  # context manager should not raise
 
 
-def test_thread_safe_sampler_concurrent_writes():
+def test_thread_safe_sampler_concurrent_writes() -> None:
     """Multiple threads can write concurrently without raising exceptions.
 
     Each thread uses its own RNG seeded by its index to avoid shared-state

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -10,6 +10,7 @@ from lupy.sampling import (
     Sampler, TruePeakSampler, ThreadSafeSampler, ThreadSafeTruePeakSampler,
     calc_buffer_length, Slice,
 )
+from lupy.types import NumChannels
 
 
 
@@ -328,7 +329,7 @@ def test_thread_safe_sampler_concurrent_writes() -> None:
     to guarantee that at least one gate-sized read is possible afterwards.
     """
     block_size = 128
-    num_channels = 1
+    num_channels: NumChannels = 1
     sample_rate = 48000
     sampler = ThreadSafeSampler(block_size=block_size, num_channels=num_channels, sample_rate=sample_rate)
 
@@ -418,7 +419,7 @@ def test_slice_calc_shape_non_last_axis() -> None:
 def test_sampler_write_float32() -> None:
     """Sampler.write converts float32 input to float64 before filtering."""
     block_size = 512
-    num_channels = 1
+    num_channels: NumChannels = 1
     sample_rate = 48000
     sampler = Sampler(block_size=block_size, num_channels=num_channels, sample_rate=sample_rate)
     rng = np.random.default_rng(0)


### PR DESCRIPTION
## Summary by Sourcery

Extend static type checking to test code and align test type annotations with the core library types.

Enhancements:
- Refine test helper type signatures to use library channel and bit-depth type aliases for stricter typing.
- Introduce a BitDepth type alias in compliance test helpers to centralize valid bit-depth values and reuse them in metadata structures and parsing.

Build:
- Update mypy configuration to type-check both source and test files.

Tests:
- Annotate test functions and fixtures with explicit return and parameter types to satisfy stricter type checking and improve test readability.
- Tighten NumChannels and related type usage in tests to better reflect supported channel configurations.