### PR TITLE
Revert "Update dependency numpy to <=2.5.0"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "numpy<=2.5.0",
+    "numpy<=2.4.6",
     "scipy<=1.18.0",
     "typing-extensions; python_version<'3.13'"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -674,7 +674,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "numpy", specifier = "<=2.5.0" },
+    { name = "numpy", specifier = "<=2.4.6" },
     { name = "scipy", specifier = "<=1.18.0" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]


### PR DESCRIPTION
Reverts nocarryr/lupy#154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated numpy dependency constraint to a more restrictive version for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->