### PR TITLE
Inherit from `ndarray` directly in record array "subclasses"

### DIFF
--- a/src/lupy/arraytypes.py
+++ b/src/lupy/arraytypes.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Generic
 
 import numpy as np
-import numpy.typing as npt
 
 
 from .types import NumChannelsT
@@ -54,13 +53,13 @@ class TruePeakDtype(np.void, Generic[NumChannelsT]):
     """
 
 
-class MeterArray(npt.NDArray[np.void]):
+class MeterArray(np.ndarray[tuple[int], np.dtype[np.void]]):
     """Array with dtype :obj:`MeterDtype`
     """
     pass
 
 
-class TruePeakArray(npt.NDArray[np.void], Generic[NumChannelsT]):
+class TruePeakArray(np.ndarray[tuple[int], np.dtype[np.void]], Generic[NumChannelsT]):
     """Array with dtype :obj:`TruePeakDtype`
     """
     pass

--- a/src/lupy/arraytypes.pyi
+++ b/src/lupy/arraytypes.pyi
@@ -25,7 +25,7 @@ class TruePeakDtype(np.void, Generic[NumChannelsT]): ... # type: ignore[misc]
 _MeterArrayFields = Literal['t', 'm', 's']
 
 
-class MeterArray(npt.NDArray[np.void]):
+class MeterArray(np.ndarray[tuple[int], np.dtype[np.void]]):
     @overload
     def __getitem__(self, key: int|slice[Any, Any, Any]) -> Self: ...
     @overload
@@ -37,7 +37,7 @@ class MeterArray(npt.NDArray[np.void]):
 _TruePeakArrayFields = Literal['t', 'tp']
 
 
-class TruePeakArray(npt.NDArray[np.void], Generic[NumChannelsT]):
+class TruePeakArray(np.ndarray[tuple[int], np.dtype[np.void]], Generic[NumChannelsT]):
     @overload
     def __getitem__(self, key: int|slice[Any, Any, Any]) -> Self: ...
     @overload


### PR DESCRIPTION
This is to avoid issues with numpy>=2.5.0 where `NDArray` is defined with the `type` statement instead of being annoated as `TypeAlias`.

See errors in #157:

```
src/lupy/arraytypes.pyi:28: error: Type alias defined using "type" statement not valid as base class  [misc]
src/lupy/arraytypes.pyi:40: error: Type alias defined using "type" statement not valid as base class  [misc]
```

```
src/lupy/arraytypes.py:57: in <module>
    class MeterArray(npt.NDArray[np.void]):
E   TypeError: typealias() takes exactly 2 positional arguments (3 given)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated type annotations for array wrapper classes to use NumPy's modern generic typing conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->